### PR TITLE
Added opacity parameter to Color hex initializer

### DIFF
--- a/SceneIt/Core/Theme.swift
+++ b/SceneIt/Core/Theme.swift
@@ -63,12 +63,13 @@ extension View {
 // ====== Hex color helper ======
 
 extension Color {
-    init(hex: String) {
+    init(hex: String, opacity: Double = 1.0) {
         let v = Int(hex, radix: 16) ?? 0
         self.init(
             red:   Double((v >> 16) & 0xFF) / 255,
             green: Double((v >> 8)  & 0xFF) / 255,
-            blue:  Double(v         & 0xFF) / 255
+            blue:  Double(v         & 0xFF) / 255,
+            opacity: opacity
         )
     }
 }


### PR DESCRIPTION
## Summary
Added opacity support to the Color hex initializer in Theme.

## Changes
- Updated `Color(hex:)` initializer with an `opacity` parameter

## Why
- The previous initializer did not support alpha values
- Allows flexible use of hex colors with transparency throughout the app
- Improved consistency and extensibility of the Theme layer

## Result
The Color hex initializer now supports optional opacity, making it easier to apply transparent hex colors across all views.