### PR TITLE
Feature/result

### DIFF
--- a/SceneIt/Core/Localizable.xcstrings
+++ b/SceneIt/Core/Localizable.xcstrings
@@ -133,6 +133,50 @@
         }
       }
     },
+    "result_body_great" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du kan dina svenska serier riktigt bra. Nästan perfekt!"
+          }
+        }
+      }
+    },
+    "result_body_keep_trying" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dags att sätta sig i soffan och kolla lite mer. Du klarar det!"
+          }
+        }
+      }
+    },
+    "result_body_ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Halvvägs dit! Lite mer binge-watching så sitter det."
+          }
+        }
+      }
+    },
+    "result_body_perfect" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otroligt! Du fick alla rätt. En sann serieexpert! 🏆"
+          }
+        }
+      }
+    },
     "result_great" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SceneIt/Features/Result/ResultView.swift
+++ b/SceneIt/Features/Result/ResultView.swift
@@ -1,10 +1,3 @@
-//
-//  ResultView.swift
-//  SceneIt
-//
-//  Created by Patrik Noordh on 2026-03-31.
-//
-
 import SwiftUI
 
 struct ResultView: View {

--- a/SceneIt/Features/Result/ResultView.swift
+++ b/SceneIt/Features/Result/ResultView.swift
@@ -1,0 +1,21 @@
+//
+//  ResultView.swift
+//  SceneIt
+//
+//  Created by Patrik Noordh on 2026-03-31.
+//
+
+import SwiftUI
+
+struct ResultView: View {
+
+    let state: ResultViewState
+
+    var body: some View {
+        Text(state.categoryName)
+    }
+}
+
+#Preview {
+    ResultView(state: .preview)
+}

--- a/SceneIt/Features/Result/ResultView.swift
+++ b/SceneIt/Features/Result/ResultView.swift
@@ -2,13 +2,148 @@ import SwiftUI
 
 struct ResultView: View {
 
-    let state: ResultViewState
+    @ObservedObject var viewModel: ResultViewModel
+    let onRestart: () -> Void
 
     var body: some View {
-        Text(state.categoryName)
+        let state = viewModel.state
+
+        ZStack {
+
+            Theme.bgGradient
+                .ignoresSafeArea()
+
+            DotsBackgroundView()
+
+            ScrollView {
+                VStack(spacing: 0) {
+
+                    VStack(spacing: 4) {
+                        Text(state.title)
+                            .font(.system(size: 20, weight: .bold))
+                            .tracking(2)
+                            .textCase(.uppercase)
+                            .foregroundStyle(Theme.primary)
+
+                        Text(state.subtitle)
+                            .font(.system(size: 10, weight: .regular))
+                            .tracking(3)
+                            .textCase(.uppercase)
+                            .foregroundStyle(Theme.primary.opacity(0.35))
+                    }
+                    .padding(.top, 32)
+                    .padding(.bottom, 16)
+
+                    Text(state.categoryName)
+                        .font(.system(size: 11, weight: .semibold))
+                        .tracking(2)
+                        .textCase(.uppercase)
+                        .foregroundStyle(Theme.primary.opacity(0.8))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 6)
+                        .background(Theme.surface.opacity(0.5))
+                        .overlay(
+                            Capsule()
+                                .stroke(
+                                    Theme.primary.opacity(0.3),
+                                    lineWidth: 1
+                                )
+                        )
+                        .clipShape(Capsule())
+                        .padding(.bottom, 24)
+
+                    ScoreCircleView(state: state)
+                        .padding(.bottom, 30)
+
+                    DividerView()
+                        .padding(.bottom, 16)
+
+                    VStack(spacing: 6) {
+                        Text(state.resultHeadLine)
+                            .font(.system(size: 16, weight: .bold))
+                            .foregroundStyle(Color.white.opacity(0.85))
+                            .multilineTextAlignment(.center)
+
+                        Text(state.resultBody)
+                            .font(Font.system(size: 13, weight: .regular))
+                            .foregroundStyle(Color.white.opacity(0.4))
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(4)
+                    }
+                    .padding(.horizontal, 32)
+                    .padding(.bottom, 32)
+
+                    Button(action: onRestart) {
+                        Text(state.playAgainButton)
+                            .font(.system(size: 14, weight: .bold))
+                            .tracking(2)
+                            .textCase(.uppercase)
+                            .foregroundStyle(Color.white.opacity(0.9))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(Theme.buttonGradient)
+                            .clipShape(Capsule())
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 20)
+
+                }
+            }
+
+        }
+
     }
+
+    private struct DotsBackgroundView: View {
+        var body: some View {
+            GeometryReader { _ in
+                Canvas { context, size in
+                    let spacing: CGFloat = 22
+                    let cols = Int(size.width / spacing) + 1
+                    let rows = Int(size.height / spacing) + 1
+                    for row in 0..<rows {
+                        for col in 0..<cols {
+                            let x = CGFloat(col) * spacing
+                            let y = CGFloat(row) * spacing
+                            let rect = CGRect(
+                                x: x - 1,
+                                y: y - 1,
+                                width: 2,
+                                height: 2
+                            )
+                            context.fill(
+                                Path(ellipseIn: rect),
+                                with: .color(Color(hex: "AD2831").opacity(0.08))
+                            )
+                        }
+                    }
+                }
+            }
+            .ignoresSafeArea()
+        }
+    }
+
+    private struct DividerView: View {
+        var body: some View {
+            LinearGradient(
+                colors: [.clear, Theme.primary.opacity(0.2), .clear],
+                startPoint: .leading,
+                endPoint: .trailing
+            )
+            .frame(height: 1)
+            .padding(.horizontal, 24)
+        }
+    }
+
 }
 
 #Preview {
-    ResultView(state: .preview)
+    ResultView(
+        viewModel: ResultViewModel(
+            score: 8,
+            totalQuestions: 10,
+            category: .komedi
+        ),
+        onRestart: {}
+    )
 }

--- a/SceneIt/Features/Result/ResultViewModel.swift
+++ b/SceneIt/Features/Result/ResultViewModel.swift
@@ -1,0 +1,23 @@
+import Combine
+import Foundation
+
+@MainActor
+final class ResultViewModel: ObservableObject {
+
+    @Published private(set) var state: ResultViewState
+
+    private let score: Int
+    private let totalQuestions: Int
+    private let category: Category
+
+    init(score: Int, totalQuestions: Int, category: Category) {
+        self.score = score
+        self.totalQuestions = totalQuestions
+        self.category = category
+        self.state = ResultViewState(
+            score: score,
+            totalQuestions: totalQuestions,
+            category: category
+        )
+    }
+}

--- a/SceneIt/Features/Result/ResultViewState.swift
+++ b/SceneIt/Features/Result/ResultViewState.swift
@@ -1,0 +1,18 @@
+//
+//  ResultViewState.swift
+//  SceneIt
+//
+//  Created by Patrik Noordh on 2026-03-31.
+//
+
+import SwiftUI
+
+struct ResultViewState: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    ResultViewState()
+}

--- a/SceneIt/Features/Result/ResultViewState.swift
+++ b/SceneIt/Features/Result/ResultViewState.swift
@@ -1,18 +1,87 @@
-//
-//  ResultViewState.swift
-//  SceneIt
-//
-//  Created by Patrik Noordh on 2026-03-31.
-//
-
 import SwiftUI
 
-struct ResultViewState: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
+struct ResultViewState {
 
-#Preview {
-    ResultViewState()
+    let score: Int
+    let totalQuestions: Int
+    let category: Category
+
+    var title: String {
+        String(localized: "result_title")
+    }
+
+    var subtitle: String {
+        String(localized: "result_subtitle")
+    }
+
+    var playAgainButton: String {
+        String(localized: "play_again_button")
+    }
+
+    var scoreOfLable: String {
+        String(localized: "score_of")
+    }
+
+    var categoryName: String {
+        switch category {
+        case .komedi: return String(localized: "category_komedi")
+        case .thriller: return String(localized: "category_thriller")
+        case .drama: return String(localized: "category_drama")
+        case .action: return String(localized: "category_action")
+        }
+    }
+
+    var scoreText: String {
+        "\(score)"
+    }
+
+    var totalText: String {
+        "\(scoreOfLable) \(totalQuestions)"
+    }
+
+    var progress: Double {
+        guard totalQuestions > 0 else { return 0 }
+        return Double(score) / Double(totalQuestions)
+    }
+
+    var resultHeadLine: String {
+        switch score {
+        case 10: return String(localized: "result_perfect")
+        case 7...9: return String(localized: "result_great")
+        case 4...6: return String(localized: "result_ok")
+        default: return String(localized: "result_keep_trying")
+        }
+    }
+
+    var resultBody: String {
+        switch score {
+        case 10:
+            return "Otroligt! Du fick alla rätt. En sann serieexpert! 🏆"
+        case 7...9:
+            return "Du kan dina svenska serier riktigt bra. Nästan perfekt!"
+        case 4...6:
+            return "Halvvägs dit! Lite mer binge-watching så sitter det."
+        default:
+            return
+                "Dags att sätta sig i soffan och kolla lite mer. Du klarar det!"
+        }
+    }
+
+    var progressColor: Color {
+        switch score {
+        case 10: return Theme.highlight
+        case 7...9: return Theme.primary
+        case 4...6: return Theme.accent
+        default: return Theme.accent.opacity(0.5)
+        }
+    }
+
+    static var preview: ResultViewState {
+        ResultViewState(
+            score: 8,
+            totalQuestions: 10,
+            category: .komedi
+        )
+    }
+
 }

--- a/SceneIt/Features/Result/ResultViewState.swift
+++ b/SceneIt/Features/Result/ResultViewState.swift
@@ -55,16 +55,11 @@ struct ResultViewState {
 
     var resultBody: String {
         switch score {
-        case 10:
-            return "Otroligt! Du fick alla rätt. En sann serieexpert! 🏆"
-        case 7...9:
-            return "Du kan dina svenska serier riktigt bra. Nästan perfekt!"
-        case 4...6:
-            return "Halvvägs dit! Lite mer binge-watching så sitter det."
-        default:
-            return
-                "Dags att sätta sig i soffan och kolla lite mer. Du klarar det!"
-        }
+         case 10:    return String(localized: "result_body_perfect")
+         case 7...9: return String(localized: "result_body_great")
+         case 4...6: return String(localized: "result_body_ok")
+         default:    return String(localized: "result_body_keep_trying")
+         }
     }
 
     var progressColor: Color {

--- a/SceneIt/Features/Result/ScoreCircleView.swift
+++ b/SceneIt/Features/Result/ScoreCircleView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct ScoreCircleView: View {
+
+    let state: ResultViewState
+
+    var body: some View {
+        
+        ZStack {
+            
+            ForEach([90.0, 78.0, 66.0], id: \.self) { radius in
+                Circle()
+                    .stroke(Theme.primary.opacity(0.07 + (90 - radius) * 0.005), lineWidth: 1)
+                    .frame(width: radius * 2, height: radius * 2)
+            }
+            
+            Circle()
+                .trim(from: 0, to: state.progress)
+                .stroke(
+                    state.progressColor,
+                    style: StrokeStyle(lineWidth: 4, lineCap: .round)
+                )
+                .frame(width: 168, height: 168)
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut(duration: 0.8), value: state.progress)
+                .glowEffect(radius: 6)
+            
+            VStack(spacing: 2) {
+                Text(state.scoreText)
+                    .font(.system(size: 64, weight: .bold, design: .rounded))
+                    .foregroundStyle(Theme.primary)
+                
+                Text(state.totalText)
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(Theme.primary.opacity(0.45))
+            }
+            .frame(width: 200, height: 200)
+            
+        }
+    }
+}
+
+#Preview {
+    ZStack {
+        Theme.bgGradient
+            .ignoresSafeArea()
+        
+        ScoreCircleView(
+            state: ResultViewState(
+                score: 8,
+                totalQuestions: 10,
+                category: .komedi
+            )
+        )
+    }
+}

--- a/SceneIt/Features/Result/ScoreCircleView.swift
+++ b/SceneIt/Features/Result/ScoreCircleView.swift
@@ -5,37 +5,41 @@ struct ScoreCircleView: View {
     let state: ResultViewState
 
     var body: some View {
-        
+
         ZStack {
-            
-            ForEach([90.0, 78.0, 66.0], id: \.self) { radius in
+
+            ForEach([160.0, 145.0, 130.0], id: \.self) { radius in
                 Circle()
-                    .stroke(Theme.primary.opacity(0.07 + (90 - radius) * 0.005), lineWidth: 1)
+                    .stroke(
+                        Theme.primary.opacity(0.07 + (160 - radius) * 0.005),
+                        lineWidth: 1
+                    )
                     .frame(width: radius * 2, height: radius * 2)
             }
-            
+
             Circle()
                 .trim(from: 0, to: state.progress)
                 .stroke(
                     state.progressColor,
-                    style: StrokeStyle(lineWidth: 4, lineCap: .round)
+                    style: StrokeStyle(lineWidth: 8, lineCap: .round)
                 )
-                .frame(width: 168, height: 168)
+                .frame(width: 280, height: 280)
                 .rotationEffect(.degrees(-90))
                 .animation(.easeInOut(duration: 0.8), value: state.progress)
-                .glowEffect(radius: 6)
-            
+                .glowEffect(radius: 10)
+
             VStack(spacing: 2) {
                 Text(state.scoreText)
-                    .font(.system(size: 64, weight: .bold, design: .rounded))
+                    .font(.system(size: 100, weight: .bold, design: .rounded))
                     .foregroundStyle(Theme.primary)
-                
+
                 Text(state.totalText)
-                    .font(.system(size: 13, weight: .regular))
+                    .font(.system(size: 18, weight: .regular))
                     .foregroundStyle(Theme.primary.opacity(0.45))
             }
-            .frame(width: 200, height: 200)
-            
+
+            .frame(width: 320, height: 320)
+
         }
     }
 }
@@ -44,7 +48,7 @@ struct ScoreCircleView: View {
     ZStack {
         Theme.bgGradient
             .ignoresSafeArea()
-        
+
         ScoreCircleView(
             state: ResultViewState(
                 score: 8,


### PR DESCRIPTION
## Summary
Added Epic 3 result screen with MVVM architecture, animated score circle and fully localized strings.

## Changes
- Added `ResultViewState` with score logic, localized strings and preview
- Added `ResultViewModel` with `@MainActor`, `final` and `private(set)` state
- Added `ResultView` with dots background, category badge and restart support
- Added `ScoreCircleView` as reusable animated progress circle component
- Replaced hardcoded result body strings with `String(localized:)` keys in `ResultViewState`
- Added `result_body_perfect/great/ok/keep_trying` keys to `Localizable.xcstrings`

## Why
- Epic 3 required a dedicated result screen to display final score and feedback
- MVVM separation keeps layout, UI-logic and business logic in separate files
- `ScoreCircleView` was extracted to its own file for potential reuse in Epic 5
- Hardcoded strings replaced to follow project localization standard

## Result
Result screen now displays score, category, encouraging message and a play
again button — ready to be connected to QuizViewModel in the next session.