### PR TITLE
Fix/result remove viewmodel dependency

### DIFF
--- a/SceneIt/Features/Result/ResultView.swift
+++ b/SceneIt/Features/Result/ResultView.swift
@@ -2,12 +2,11 @@ import SwiftUI
 
 struct ResultView: View {
 
-    @ObservedObject var viewModel: ResultViewModel
+    let state: ResultViewState
     let onRestart: () -> Void
 
     var body: some View {
-        let state = viewModel.state
-
+        
         ZStack {
 
             Theme.bgGradient
@@ -138,12 +137,5 @@ struct ResultView: View {
 }
 
 #Preview {
-    ResultView(
-        viewModel: ResultViewModel(
-            score: 8,
-            totalQuestions: 10,
-            category: .komedi
-        ),
-        onRestart: {}
-    )
+    ResultView(state: .preview, onRestart: {})
 }

--- a/SceneIt/Features/Result/ResultViewModel.swift
+++ b/SceneIt/Features/Result/ResultViewModel.swift
@@ -5,19 +5,14 @@ import Foundation
 final class ResultViewModel: ObservableObject {
 
     @Published private(set) var state: ResultViewState
+   
 
-    private let score: Int
-    private let totalQuestions: Int
-    private let category: Category
 
     init(score: Int, totalQuestions: Int, category: Category) {
-        self.score = score
-        self.totalQuestions = totalQuestions
-        self.category = category
-        self.state = ResultViewState(
-            score: score,
-            totalQuestions: totalQuestions,
-            category: category
-        )
-    }
+           self.state = ResultViewState(
+               score: score,
+               totalQuestions: totalQuestions,
+               category: category
+           )
+       }
 }


### PR DESCRIPTION
## Summary
Fixed ResultView and ResultViewModel to follow strict MVVM architecture.

## Changes
- Replaced `@ObservedObject var viewModel: ResultViewModel` with `let state: ResultViewState` in `ResultView`
- Removed `let state = viewModel.state` from `ResultView` body
- Updated `#Preview` in `ResultView` to use `ResultViewState.preview` directly
- Removed redundant private stored properties `score`, `totalQuestions` and `category` from `ResultViewModel`

## Why
- `ResultView` was coupled to `ResultViewModel` breaking the MVVM rule that View only knows about ViewState
- Storing `score`, `totalQuestions` and `category` as private properties in `ResultViewModel` was redundant since all data already lived in `ResultViewState`
- Brings `ResultView` in line with `StartView` and `QuizView` which only receive state and closures

## Result
`ResultView` now only knows about `ResultViewState` and an `onRestart` closure, consistent with the strict MVVM pattern used throughout the project.