### PR TITLE
refacor: cleaned up start feature architecture

### DIFF
--- a/SceneIt/Features/Start/StartView.swift
+++ b/SceneIt/Features/Start/StartView.swift
@@ -119,6 +119,8 @@ struct StartView: View {
                 .cornerRadius(28)
 
                 .glowEffect()
+                
+                .disabled(!state.isStartButtonEnabled)
 
             }
 

--- a/SceneIt/Features/Start/StartViewModel.swift
+++ b/SceneIt/Features/Start/StartViewModel.swift
@@ -1,16 +1,17 @@
 import Combine
-import SwiftUI
+import Foundation
  
 class StartViewModel: ObservableObject {
+ 
     @Published var state = StartViewState()
  
-    init() {
+    init(onStart: @escaping (Category) -> Void) {
         state.onSelectCategory = { [weak self] category in
             self?.state.selectedCategory = category
         }
         state.onStart = { [weak self] in
-            guard self?.state.selectedCategory != nil else { return }
-            self?.state.showQuiz = true
+            guard let category = self?.state.selectedCategory else { return }
+            onStart(category)
         }
     }
 }

--- a/SceneIt/Features/Start/StartViewState.swift
+++ b/SceneIt/Features/Start/StartViewState.swift
@@ -1,66 +1,21 @@
-import SwiftUI
+import Foundation
  
 struct StartViewState {
-
     var categories: [CategoryItem] = CategoryItem.all
-
     var questionCount: Int = 10
-
     var optionCount: Int = 4
-
-    var showQuiz: Bool = false
-
     var selectedCategory: Category? = nil
  
     var appName: String { NSLocalizedString("app_name", comment: "") }
-
     var tagline: String { NSLocalizedString("app_tagline", comment: "") }
-
     var selectCategoryLabel: String { NSLocalizedString("select_category", comment: "") }
-
     var startButtonLabel: String { NSLocalizedString("start_button", comment: "") }
-
     var questionsLabel: String { NSLocalizedString("questions_count", comment: "") }
-
     var optionsLabel: String { NSLocalizedString("options_count", comment: "") }
+    var isStartButtonEnabled: Bool { selectedCategory != nil }
  
     var onSelectCategory: (Category) -> Void = { _ in }
-
     var onStart: () -> Void = { }
  
-    static var preview: StartViewState {
-
-        StartViewState()
-
-    }
-
+    static var preview: StartViewState { StartViewState() }
 }
- 
-struct CategoryItem: Identifiable {
-
-    let id = UUID()
-
-    let category: Category
-
-    let icon: String
-
-    let suffix: String
- 
-    static var all: [CategoryItem] = [
-
-        CategoryItem(category: .thriller, icon: "🔪", suffix: NSLocalizedString("questions_suffix", comment: "")),
-
-        CategoryItem(category: .drama,    icon: "🎭", suffix: NSLocalizedString("questions_suffix", comment: "")),
-
-        CategoryItem(category: .komedi,   icon: "😂", suffix: NSLocalizedString("questions_suffix", comment: "")),
-
-        CategoryItem(category: .action,   icon: "💥", suffix: NSLocalizedString("questions_suffix", comment: ""))
-
-    ]
- 
-    var displayName: String { category.displayName }
-
-    var countLabel: String { "10 \(suffix)" }
-
-}
- 

--- a/SceneIt/Models/Category.swift
+++ b/SceneIt/Models/Category.swift
@@ -17,3 +17,32 @@ enum Category: String, Codable, CaseIterable {
         }
     }
 }
+
+struct CategoryItem: Identifiable {
+ 
+    let id = UUID()
+ 
+    let category: Category
+ 
+    let icon: String
+ 
+    let suffix: String
+ 
+    static var all: [CategoryItem] = [
+ 
+        CategoryItem(category: .thriller, icon: "🔪", suffix: NSLocalizedString("questions_suffix", comment: "")),
+ 
+        CategoryItem(category: .drama,    icon: "🎭", suffix: NSLocalizedString("questions_suffix", comment: "")),
+ 
+        CategoryItem(category: .komedi,   icon: "😂", suffix: NSLocalizedString("questions_suffix", comment: "")),
+ 
+        CategoryItem(category: .action,   icon: "💥", suffix: NSLocalizedString("questions_suffix", comment: ""))
+ 
+    ]
+ 
+    var displayName: String { category.displayName }
+ 
+    var countLabel: String { "10 \(suffix)" }
+ 
+}
+ 


### PR DESCRIPTION
## Summary
Refactored start feature to follow clean architecture.
 
## Changes
- Updated `StartViewState` to only contain data, removed callbacks and `showQuiz`
- Updated `StartViewModel` to accept `onStart` callback in init
- Moved `CategoryItem` to `Category.swift` in the Models layer
 
## Why
- Separated data from actions in `StartViewState`
- Decoupled navigation logic from the start feature
- Prepared for `AppViewModel` integration
 
## Result
Start feature now follows a clean separation between layout, state and business logic.