### PR TITLE
Refactor/result feature

### DIFF
--- a/SceneIt/Features/Result/ResultView.swift
+++ b/SceneIt/Features/Result/ResultView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ResultView: View {
 
     let state: ResultViewState
-    let onRestart: () -> Void
+    
 
     var body: some View {
         
@@ -72,7 +72,7 @@ struct ResultView: View {
                     .padding(.horizontal, 32)
                     .padding(.bottom, 32)
 
-                    Button(action: onRestart) {
+                    Button(action: state.onRestart) {
                         Text(state.playAgainButton)
                             .font(.system(size: 14, weight: .bold))
                             .tracking(2)
@@ -137,5 +137,5 @@ struct ResultView: View {
 }
 
 #Preview {
-    ResultView(state: .preview, onRestart: {})
+    ResultView(state: .preview)
 }

--- a/SceneIt/Features/Result/ResultViewModel.swift
+++ b/SceneIt/Features/Result/ResultViewModel.swift
@@ -4,15 +4,16 @@ import Foundation
 @MainActor
 final class ResultViewModel: ObservableObject {
 
-    @Published private(set) var state: ResultViewState
-   
+    @Published var state: ResultViewState
 
-
-    init(score: Int, totalQuestions: Int, category: Category) {
-           self.state = ResultViewState(
-               score: score,
-               totalQuestions: totalQuestions,
-               category: category
-           )
-       }
+    init(score: Int, totalQuestions: Int, category: Category, onRestart: @escaping () -> Void) {
+        self.state = ResultViewState(
+            score: score,
+            totalQuestions: totalQuestions,
+            category: category
+        )
+        self.state.onRestart = onRestart
+        
+    }
+    
 }

--- a/SceneIt/Features/Result/ResultViewState.swift
+++ b/SceneIt/Features/Result/ResultViewState.swift
@@ -17,6 +17,8 @@ struct ResultViewState {
     var playAgainButton: String {
         String(localized: "play_again_button")
     }
+    
+    var onRestart: () -> Void = { }
 
     var scoreOfLable: String {
         String(localized: "score_of")

--- a/SceneIt/SceneItApp.swift
+++ b/SceneIt/SceneItApp.swift
@@ -23,12 +23,12 @@ struct SceneItApp: App {
  
             case .result(let score, let total, let category):
                 ResultView(
-                    viewModel: ResultViewModel(
+                    state: ResultViewModel(
                         score: score,
                         totalQuestions: total,
-                        category: category
-                    ),
-                    onRestart: appViewModel.restart
+                        category: category,
+                        onRestart: appViewModel.restart
+                    ).state
                 )
             }
         }


### PR DESCRIPTION
## Summary
Moved `onRestart` callback into `ResultViewState` and updated `ResultViewModel` to match the Start feature pattern.

## Changes
- Added `onRestart` closure to `ResultViewState` with default empty implementation
- Updated `ResultViewModel.init` to accept `onRestart` parameter and wire it to state
- Removed `private(set)` from `ResultViewModel.state` to allow mutation
- Removed standalone `let onRestart` from `ResultView`, now uses `state.onRestart`
- Updated `SceneItApp` result case to create `ResultViewModel` with `onRestart` and pass `.state`

## Why
- `ResultView` had a separate `onRestart` callback outside of state, inconsistent with `StartView` pattern
- Aligning all features to the same architecture makes the codebase predictable and maintainable
- Prepares `ResultViewModel` for epic 5 (highscore logic) by keeping it as the callback wiring point

## Result
Result feature now follows the same View/State/ViewModel pattern as Start, where callbacks live in state and `ViewModel` wires them in `init`.