### PR TITLE
refactor: QuizView observes QuizViewModel

### DIFF
--- a/SceneIt/AppViewModel.swift
+++ b/SceneIt/AppViewModel.swift
@@ -1,7 +1,6 @@
 import Combine
 import Foundation
 
-s
 enum AppScreen {
     case start
     case quiz(category: Category)

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -15,11 +15,13 @@ private struct ButtonFrameKey: PreferenceKey {
 }
 
 struct QuizView: View {
-    let state: QuizViewState
+    @ObservedObject var viewModel: QuizViewModel
     @State private var questionFrame: CGRect = .zero
     @State private var buttonFrames: [Int: CGRect] = [:]
 
     var body: some View {
+        let state = viewModel.state
+        
         ZStack {
             Theme.bgGradient
                 .ignoresSafeArea()
@@ -200,5 +202,5 @@ extension Array {
 }
 
 #Preview {
-    QuizView(state: .preview)
+    QuizView(viewModel: QuizViewModel(category: .komedi, onFinished: { _, _, _ in }))
 }

--- a/SceneIt/Features/Quiz/QuizViewModel.swift
+++ b/SceneIt/Features/Quiz/QuizViewModel.swift
@@ -1,8 +1,9 @@
 import Combine
 import Foundation
 
-class QuizViewModel: ObservableObject {
-    @Published var state = QuizViewState()
+@MainActor
+final class QuizViewModel: ObservableObject {
+    @Published private(set) var state = QuizViewState()
 
     private var questions: [Question] = []
     private let category: Category
@@ -19,7 +20,6 @@ class QuizViewModel: ObservableObject {
         state.onNextQuestion = { [weak self] in
             self?.nextQuestion()
         }
-        
     }
 
     private func selectAnswer(_ index: Int) {


### PR DESCRIPTION
## Summary
Refactored quiz feature so the view observes the ViewModel directly.

## Changes
- Updated \`QuizView\` to use \`@ObservedObject var viewModel: QuizViewModel\`
- Updated \`QuizViewModel\` with \`@MainActor\`, \`final\`, and \`private(set)\`
- Fixed stray character in \`AppViewModel\`

## Why
- Standardized observation pattern already used in \`StartView\` and \`ResultView\`
- Ensures SwiftUI re-renders on state changes
- Thread safety via \`@MainActor\`

## Result
Quiz feature now follows the same ViewModel observation pattern as Start and Result."
