### PR TITLE
fixed: quiz layout and theme colors to match prototype

### DIFF
--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/Background.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/Background.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x02",
-          "green" : "0x09",
-          "red" : "0x25"
+          "blue" : "0x01",
+          "green" : "0x01",
+          "red" : "0x0D"
         }
       },
       "idiom" : "universal"

--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/Card.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/Card.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x06",
-          "green" : "0x04",
-          "red" : "0x30"
+          "green" : "0x03",
+          "red" : "0x1E"
         }
       },
       "idiom" : "universal"

--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/Text.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/Text.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x06",
-          "green" : "0x04",
-          "red" : "0x30"
+          "blue" : "0xD2",
+          "green" : "0xD2",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/SceneIt/Core/OctagonShape.swift
+++ b/SceneIt/Core/OctagonShape.swift
@@ -1,22 +1,29 @@
-// OctagonShape.swift
 import SwiftUI
 
-struct OctagonShape: Shape {
+struct OctagonShape: Shape, InsettableShape {
     var cut: CGFloat = 20
+    var insetAmount: CGFloat = 0
 
     func path(in rect: CGRect) -> Path {
         let cut = self.cut
+        let r = rect.insetBy(dx: insetAmount, dy: insetAmount)
         var path = Path()
-        path.move(to: CGPoint(x: rect.minX + cut, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX - cut, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.minY + cut))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - cut))
-        path.addLine(to: CGPoint(x: rect.maxX - cut, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX + cut, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY - cut))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + cut))
+        path.move(to: CGPoint(x: r.minX + cut, y: r.minY))
+        path.addLine(to: CGPoint(x: r.maxX - cut, y: r.minY))
+        path.addLine(to: CGPoint(x: r.maxX, y: r.minY + cut))
+        path.addLine(to: CGPoint(x: r.maxX, y: r.maxY - cut))
+        path.addLine(to: CGPoint(x: r.maxX - cut, y: r.maxY))
+        path.addLine(to: CGPoint(x: r.minX + cut, y: r.maxY))
+        path.addLine(to: CGPoint(x: r.minX, y: r.maxY - cut))
+        path.addLine(to: CGPoint(x: r.minX, y: r.minY + cut))
         path.closeSubpath()
         return path
+    }
+
+    func inset(by amount: CGFloat) -> OctagonShape {
+        var shape = self
+        shape.insetAmount += amount
+        return shape
     }
 }
 

--- a/SceneIt/Core/Theme.swift
+++ b/SceneIt/Core/Theme.swift
@@ -4,33 +4,40 @@ import SwiftUI
 
 struct Theme {
 
-    static let background  = Color("SceneIt Colors/Background")
-    static let surface     = Color("SceneIt Colors/Surface")
-    static let primary     = Color("SceneIt Colors/Primary")
-    static let accent      = Color("SceneIt Colors/Accent")
-    static let highlight   = Color("SceneIt Colors/Highlight")
-
+    static let background = Color("SceneIt Colors/Background")
+    static let surface = Color("SceneIt Colors/Surface")
+    static let primary = Color("SceneIt Colors/Primary")
+    static let accent = Color("SceneIt Colors/Accent")
+    static let highlight = Color("SceneIt Colors/Highlight")
+    static let text        = Color("SceneIt Colors/Text")
+    
     // ====== Feedback colors ======
 
-    static let correctBg   = Color(hex: "1A6B35")
+    static let correctBg = Color(hex: "1A6B35")
     static let correctText = Color(hex: "7EFFA8")
-    static let wrongBg     = Color(hex: "6B1A1A")
-    static let wrongText   = Color(hex: "FFAAAA")
+    static let wrongBg = Color(hex: "6B1A1A")
+    static let wrongText = Color(hex: "FFAAAA")
 
     // ====== Gradients ======
 
     static let buttonGradient = LinearGradient(
-        colors: [Color("SceneIt Colors/Primary"), Color("SceneIt Colors/Accent")],
+        colors: [
+            Color("SceneIt Colors/Primary"), Color("SceneIt Colors/Accent"),
+        ],
         startPoint: .leading,
         endPoint: .trailing
     )
     static let bgGradient = LinearGradient(
-        colors: [Color("SceneIt Colors/Surface"), Color("SceneIt Colors/Background")],
+        colors: [
+            Color("SceneIt Colors/Surface"), Color("SceneIt Colors/Background"),
+        ],
         startPoint: .top,
         endPoint: .bottom
     )
     static let progressGradient = LinearGradient(
-        colors: [Color("SceneIt Colors/Primary"), Color("SceneIt Colors/Highlight")],
+        colors: [
+            Color("SceneIt Colors/Primary"), Color("SceneIt Colors/Highlight"),
+        ],
         startPoint: .leading,
         endPoint: .trailing
     )
@@ -56,7 +63,12 @@ struct GlowModifier: ViewModifier {
 
 extension View {
     func glowEffect(radius: CGFloat = 10) -> some View {
-        modifier(GlowModifier(color: Color("SceneIt Colors/Highlight"), radius: radius))
+        modifier(
+            GlowModifier(
+                color: Color("SceneIt Colors/Highlight"),
+                radius: radius
+            )
+        )
     }
 }
 
@@ -66,9 +78,9 @@ extension Color {
     init(hex: String, opacity: Double = 1.0) {
         let v = Int(hex, radix: 16) ?? 0
         self.init(
-            red:   Double((v >> 16) & 0xFF) / 255,
-            green: Double((v >> 8)  & 0xFF) / 255,
-            blue:  Double(v         & 0xFF) / 255,
+            red: Double((v >> 16) & 0xFF) / 255,
+            green: Double((v >> 8) & 0xFF) / 255,
+            blue: Double(v & 0xFF) / 255,
             opacity: opacity
         )
     }

--- a/SceneIt/Features/Quiz/AnswerButton.swift
+++ b/SceneIt/Features/Quiz/AnswerButton.swift
@@ -12,14 +12,14 @@ struct AnswerButton: View {
     private var letter: String { letters[index] }
 
     var background: Color {
-        guard showFeedback else { return Theme.surface }
+        guard showFeedback else { return .clear}
         if isCorrect { return Theme.correctBg }
         if isSelected { return Theme.wrongBg }
-        return Theme.surface
+        return .clear
     }
 
     var foreground: Color {
-        guard showFeedback else { return .white }
+        guard showFeedback else {return Theme.text.opacity(0.85)}
         if isCorrect { return Theme.correctText }
         if isSelected { return Theme.wrongText }
         return .white.opacity(0.4)

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -70,14 +70,18 @@ struct QuizView: View {
                         .foregroundStyle(Theme.highlight)
                         .padding(.horizontal, 10)
                         .padding(.vertical, 4)
-                        .background(Theme.surface)
+                        .background(Theme.primary.opacity(0.2))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Theme.highlight.opacity(0.2), lineWidth: 1)
+                        )
                         .cornerRadius(12)
                 }
                 .padding(.horizontal)
                 .padding(.top)
 
                 ProgressView(value: state.progress)
-                    .tint(Theme.highlight)
+                    .tint(Theme.primary)
                     .padding(.horizontal)
                     .padding(.top, 8)
 
@@ -87,24 +91,51 @@ struct QuizView: View {
                 Text(state.question)
                     .font(.body)
                     .fontWeight(.semibold)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(Theme.text.opacity(0.85))
                     .multilineTextAlignment(.center)
-                    .padding(.vertical, 28)
+                    .padding(.vertical, 24)
                     .padding(.horizontal, 16)
                     .frame(maxWidth: .infinity)
-                    .background(Theme.surface)
-                    .clipShape(OctagonShape(cut: 20))
-                    .overlay(OctagonShape(cut: 20).stroke(Theme.highlight, lineWidth: 1.5))
+                    .background(Color.clear)
+                    .clipShape(OctagonShape(cut: 10))
+                    .overlay(
+                        ZStack {
+                            OctagonShape(cut: 10).stroke(Theme.highlight.opacity(0.4), lineWidth: 1.3)
+                            OctagonShape(cut: 10).inset(by: 8).stroke(Theme.highlight.opacity(0.3), lineWidth: 0.7)
+                            GeometryReader { geo in
+                                Path { p in
+                                    p.move(to: CGPoint(x: geo.size.width * 0.3, y: 0))
+                                    p.addLine(to: CGPoint(x: geo.size.width * 0.7, y: 0))
+                                }
+                                .stroke(Theme.highlight.opacity(0.6), lineWidth: 2)
+                            }
+                            GeometryReader { geo in
+                                Path { p in
+                                    p.move(to: CGPoint(x: 0, y: geo.size.height * 0.35))
+                                    p.addLine(to: CGPoint(x: 0, y: geo.size.height * 0.45))
+                                }
+                                .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
+                            }
+                            GeometryReader { geo in
+                                Path { p in
+                                    p.move(to: CGPoint(x: geo.size.width, y: geo.size.height * 0.35))
+                                    p.addLine(to: CGPoint(x: geo.size.width, y: geo.size.height * 0.45))
+                                }
+                                .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
+                            }
+                        }
+                    )
                     .padding(.horizontal, 16)
-                    .background(
+                    .background(                              // ← behåll denna!
                         GeometryReader { geo in
                             Color.clear.preference(
                                 key: QuestionFrameKey.self,
-                                value: geo.frame(in: .global)
+                                value: geo.frame(in: .named("quiz"))
                             )
                         }
                     )
                     .onPreferenceChange(QuestionFrameKey.self) { questionFrame = $0 }
+
 
                 // A och B
                 HStack {


### PR DESCRIPTION
## Summary
Updated quiz layout and shared theme colors to match the HTML prototype.

## Changes
- Updated `OctagonShape` with `InsettableShape` conformance
- Updated `QuizView` question card shape, padding and decorative details
- Updated `AnswerButton` with clear background and correct text color
- Added `Theme.text` color (`FFD2D2`) to Assets and Theme
- Updated background gradient colors (`Surface`, `Background`) in Assets
- Fixed score pill background and progress bar tint

## Why
- Quiz screen did not match the prototype design
- Shared colors needed to be consistent across the app
- Ruth's start screen will benefit from the same background colors

## Result
Quiz screen now matches the prototype with correct colors, card shape and transparent answer buttons.
