### PR TITLE
Fix/localization dots score animation

### DIFF
--- a/SceneIt/Core/DotsBackgroundView.swift
+++ b/SceneIt/Core/DotsBackgroundView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct DotsBackgroundView: View {
+    var body: some View {
+        GeometryReader { _ in
+            Canvas { context, size in
+                let spacing: CGFloat = 22
+                let cols = Int(size.width / spacing) + 1
+                let rows = Int(size.height / spacing) + 1
+                for row in 0..<rows {
+                    for col in 0..<cols {
+                        let x = CGFloat(col) * spacing
+                        let y = CGFloat(row) * spacing
+                        let rect = CGRect(
+                            x: x - 1,
+                            y: y - 1,
+                            width: 2,
+                            height: 2
+                        )
+                        context.fill(
+                            Path(ellipseIn: rect),
+                            with: .color(Color(hex: "AD2831").opacity(0.08))
+                        )
+                    }
+                }
+            }
+        }
+        .ignoresSafeArea()
+    }
+}

--- a/SceneIt/Core/Localizable.xcstrings
+++ b/SceneIt/Core/Localizable.xcstrings
@@ -42,6 +42,17 @@
         }
       }
     },
+    "category_comedy" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komedi"
+          }
+        }
+      }
+    },
     "category_drama" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -49,17 +60,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Drama"
-          }
-        }
-      }
-    },
-    "category_komedi" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komedi"
           }
         }
       }
@@ -225,17 +225,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Perfekt! Du kan allt!"
-          }
-        }
-      }
-    },
-    "result_subtitle" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Svenskt serie-quiz"
           }
         }
       }

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -9,7 +9,8 @@ struct QuizView: View {
         ZStack {
             Theme.bgGradient
                 .ignoresSafeArea()
-
+            
+            DotsBackgroundView()
 
             VStack(spacing: 0) {
 
@@ -134,5 +135,5 @@ extension Array {
 }
 
 #Preview {
-    QuizView(viewModel: QuizViewModel(category: .komedi, onFinished: { _, _, _ in }))
+    QuizView(viewModel: QuizViewModel(category: .comedy, onFinished: { _, _, _ in }))
 }

--- a/SceneIt/Features/Result/ResultView.swift
+++ b/SceneIt/Features/Result/ResultView.swift
@@ -4,6 +4,8 @@ struct ResultView: View {
 
     
     @ObservedObject var viewModel: ResultViewModel
+    
+    @State private var animateScore: Bool = false
 
     var body: some View {
         
@@ -53,7 +55,10 @@ struct ResultView: View {
                         .clipShape(Capsule())
                         .padding(.bottom, 24)
 
-                    ScoreCircleView(state: state)
+                    ScoreCircleView(state: state, animateScore: $animateScore)
+                        .onAppear {
+                            animateScore = true
+                        }
                         .padding(.bottom, 30)
 
                     DividerView()
@@ -95,34 +100,6 @@ struct ResultView: View {
 
     }
 
-    private struct DotsBackgroundView: View {
-        var body: some View {
-            GeometryReader { _ in
-                Canvas { context, size in
-                    let spacing: CGFloat = 22
-                    let cols = Int(size.width / spacing) + 1
-                    let rows = Int(size.height / spacing) + 1
-                    for row in 0..<rows {
-                        for col in 0..<cols {
-                            let x = CGFloat(col) * spacing
-                            let y = CGFloat(row) * spacing
-                            let rect = CGRect(
-                                x: x - 1,
-                                y: y - 1,
-                                width: 2,
-                                height: 2
-                            )
-                            context.fill(
-                                Path(ellipseIn: rect),
-                                with: .color(Color(hex: "AD2831").opacity(0.08))
-                            )
-                        }
-                    }
-                }
-            }
-            .ignoresSafeArea()
-        }
-    }
 
     private struct DividerView: View {
         var body: some View {
@@ -139,5 +116,5 @@ struct ResultView: View {
 }
 
 #Preview {
-    ResultView(viewModel: ResultViewModel(score: 7, totalQuestions: 10, category: .komedi, onRestart: {}))
+    ResultView(viewModel: ResultViewModel(score: 7, totalQuestions: 10, category: .comedy, onRestart: {}))
 }

--- a/SceneIt/Features/Result/ResultViewState.swift
+++ b/SceneIt/Features/Result/ResultViewState.swift
@@ -11,7 +11,7 @@ struct ResultViewState {
     }
 
     var subtitle: String {
-        String(localized: "result_subtitle")
+        String(localized: "app_tagline")
     }
 
     var playAgainButton: String {
@@ -26,7 +26,7 @@ struct ResultViewState {
 
     var categoryName: String {
         switch category {
-        case .komedi: return String(localized: "category_komedi")
+        case .comedy: return String(localized: "category_comedy")
         case .thriller: return String(localized: "category_thriller")
         case .drama: return String(localized: "category_drama")
         case .action: return String(localized: "category_action")
@@ -77,7 +77,7 @@ struct ResultViewState {
         ResultViewState(
             score: 8,
             totalQuestions: 10,
-            category: .komedi
+            category: .comedy
         )
     }
 

--- a/SceneIt/Features/Result/ScoreCircleView.swift
+++ b/SceneIt/Features/Result/ScoreCircleView.swift
@@ -4,6 +4,8 @@ struct ScoreCircleView: View {
 
     let state: ResultViewState
 
+    @Binding var animateScore: Bool
+
     var body: some View {
 
         ZStack {
@@ -18,14 +20,14 @@ struct ScoreCircleView: View {
             }
 
             Circle()
-                .trim(from: 0, to: state.progress)
+                .trim(from: 0, to: animateScore ? state.progress : 0)
                 .stroke(
                     state.progressColor,
                     style: StrokeStyle(lineWidth: 8, lineCap: .round)
                 )
                 .frame(width: 280, height: 280)
                 .rotationEffect(.degrees(-90))
-                .animation(.easeInOut(duration: 0.8), value: state.progress)
+                .animation(.easeInOut(duration: 0.8), value: animateScore)
                 .glowEffect(radius: 10)
 
             VStack(spacing: 2) {
@@ -48,13 +50,9 @@ struct ScoreCircleView: View {
     ZStack {
         Theme.bgGradient
             .ignoresSafeArea()
-
         ScoreCircleView(
-            state: ResultViewState(
-                score: 8,
-                totalQuestions: 10,
-                category: .komedi
-            )
+            state: ResultViewState(score: 8, totalQuestions: 10, category: .comedy),
+            animateScore: .constant(true)
         )
     }
 }

--- a/SceneIt/Features/Start/StartView.swift
+++ b/SceneIt/Features/Start/StartView.swift
@@ -1,15 +1,18 @@
 import SwiftUI
- 
+
 struct StartView: View {
- 
+
     @ObservedObject var viewModel: StartViewModel
- 
+
     var body: some View {
         let state = viewModel.state
- 
+
         ZStack {
             Theme.bgGradient
                 .ignoresSafeArea()
+
+            DotsBackgroundView()
+
             VStack(spacing: 16) {
                 RoundedRectangle(cornerRadius: 14)
                     .fill(Theme.buttonGradient)
@@ -46,7 +49,7 @@ struct StartView: View {
                         )
                     }
                 }
-            
+
                 Divider()
                     .overlay(Theme.highlight.opacity(0.6))
                 HStack(spacing: 8) {
@@ -60,7 +63,7 @@ struct StartView: View {
                     )
                 }
                 .padding(30)
-                
+
                 if state.isStartButtonEnabled {
                     Button(state.startButtonLabel) {
                         state.onStart()
@@ -84,7 +87,7 @@ struct StartView: View {
         }
     }
 }
- 
+
 #Preview {
     StartView(viewModel: StartViewModel())
 }

--- a/SceneIt/Models/Category.swift
+++ b/SceneIt/Models/Category.swift
@@ -1,16 +1,23 @@
 import Foundation
 
 enum Category: String, Codable, CaseIterable {
-    case komedi = "Komedi"
+    case comedy = "Komedi"
     case thriller = "Thriller"
     case drama = "Drama"
     case action = "Action"
 
-    var displayName: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .comedy: return String(localized: "category_comedy")
+        case .thriller: return String(localized: "category_thriller")
+            case .drama:    return String(localized: "category_drama")
+            case .action:   return String(localized: "category_action")
+        }
+    }
 
     var series: [String] {
         switch self {
-        case .komedi: return ["Solsidan", "Bonusfamiljen", "Svensson Svensson"]
+        case .comedy: return ["Solsidan", "Bonusfamiljen", "Svensson Svensson"]
         case .thriller: return ["Johan Falk", "Beck", "Veronika"]
         case .drama: return ["Störst av allt", "Knutby", "Tunna blå linjen"]
         case .action: return ["Snabba Cash", "Gåsmamman", "Jägarna"]
@@ -29,15 +36,10 @@ struct CategoryItem: Identifiable {
     let suffix: String
  
     static var all: [CategoryItem] = [
- 
-        CategoryItem(category: .thriller, icon: "🔪", suffix: NSLocalizedString("questions_suffix", comment: "")),
- 
-        CategoryItem(category: .drama,    icon: "🎭", suffix: NSLocalizedString("questions_suffix", comment: "")),
- 
-        CategoryItem(category: .komedi,   icon: "😂", suffix: NSLocalizedString("questions_suffix", comment: "")),
- 
-        CategoryItem(category: .action,   icon: "💥", suffix: NSLocalizedString("questions_suffix", comment: ""))
- 
+        CategoryItem(category: .thriller, icon: "🔪", suffix: String(localized: "questions_suffix")),
+        CategoryItem(category: .drama,    icon: "🎭", suffix: String(localized: "questions_suffix")),
+        CategoryItem(category: .comedy,   icon: "😂", suffix: String(localized: "questions_suffix")),
+        CategoryItem(category: .action,   icon: "💥", suffix: String(localized: "questions_suffix"))
     ]
  
     var displayName: String { category.displayName }


### PR DESCRIPTION
## Summary
Refactored app navigation layer to full MVVM, extracted shared UI components, and fixed two crashes causing the app to fail on launch and result screen.

## Changes
- Refactored `AppViewModel` to own `startViewModel`, `quizViewModel` and `resultViewModel` as `@Published private(set)` properties with a proper `restart()` that nils all ViewModels
- Updated `SceneItApp` to pass ViewModels (not `.state`) to `StartView`, `QuizView` and `ResultView`
- Updated `ResultView` to use `@ObservedObject var viewModel: ResultViewModel` with `@State private var animateScore` driving the score animation
- Updated `ResultViewModel` with `private(set)` on state to prevent external mutation
- Updated `ResultViewState.subtitle` to use `app_tagline` localization key instead of removed `result_subtitle`
- Updated `ScoreCircleView` with `@Binding var animateScore` and `.trim(from: 0, to: animateScore ? state.progress : 0)` to correctly trigger arc animation
- Extracted `DotsBackgroundView` from `ResultView` into a shared `Core` component used by `StartView`, `QuizView` and `ResultView`
- Fixed `Category` enum — renamed `.komedi` to `.comedy` and replaced `rawValue` in `displayName` with `String(localized:)` per category
- Fixed `questions.json` — removed invalid `//` comments causing a fatal `dataCorrupted` crash on launch

## Why
- `ResultViewModel` was created inline and immediately discarded in `SceneItApp`, breaking SwiftUI's observation cycle and causing the result screen to never re-render
- `//` comments in `questions.json` are not valid JSON and caused a fatal crash before any view was shown
- `DotsBackgroundView` was duplicated as a private struct in `ResultView` — extracting it removes duplication and makes it available across all screens

## Result
App navigates correctly through all screens, the result screen animates the score arc on appear, and the app launches without crashes on all categories.