### PR TITLE
refactored: move answer button color logic from view to QuizViewState

### DIFF
--- a/SceneIt/Features/Quiz/AnswerButton.swift
+++ b/SceneIt/Features/Quiz/AnswerButton.swift
@@ -3,41 +3,16 @@ import SwiftUI
 struct AnswerButton: View {
     let index: Int
     let label: String
-    let isCorrect: Bool
-    let isSelected: Bool
     let showFeedback: Bool
     let onSelectAnswer: (Int) -> Void
 
     private let letters = ["A", "B", "C", "D"]
     private var letter: String { letters[index] }
 
-    var background: Color {
-        guard showFeedback else { return .clear }
-        if isCorrect { return Theme.correctBg.opacity(0.5) }
-        if isSelected { return Theme.wrongBg.opacity(0.5) }
-        return .clear
-    }
-
-    var foreground: Color {
-        guard showFeedback else { return Theme.text.opacity(0.85) }
-        if isCorrect { return Theme.correctText }
-        if isSelected { return Theme.wrongText }
-        return .white.opacity(0.4)
-    }
-
-    var border: Color {
-        guard showFeedback else { return Theme.highlight.opacity(0.3) }
-        if isCorrect { return Theme.correctText.opacity(0.4) }
-        if isSelected { return Theme.wrongText.opacity(0.4) }
-        return Theme.highlight.opacity(0.1)
-    }
-
-    var badgeBackground: Color {
-        guard showFeedback else { return Theme.primary }
-        if isCorrect { return Theme.correctBg }
-        if isSelected { return Theme.wrongBg }
-        return Theme.primary.opacity(0.3)
-    }
+    let background: Color
+    let foreground: Color
+    let border: Color
+    let badgeBackground: Color
 
     var body: some View {
         Button {
@@ -46,7 +21,6 @@ struct AnswerButton: View {
             HStack(spacing: 0) {
 
                 if index % 2 == 0 {
-                    // A och C — bokstav till vänster
                     badgeView
                     Text(label)
                         .font(.caption)
@@ -56,7 +30,6 @@ struct AnswerButton: View {
                         .padding(.horizontal, 8)
                         .frame(maxWidth: .infinity)
                 } else {
-                    // B och D — bokstav till höger
                     Text(label)
                         .font(.caption)
                         .fontWeight(.semibold)

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -51,7 +51,6 @@ struct QuizView: View {
                     .foregroundStyle(Theme.highlight.opacity(0.4))
                     .padding(.bottom, 48)
 
-                // Frågeruta
                 Text(state.question)
                     .font(.body)
                     .fontWeight(.semibold)
@@ -91,16 +90,17 @@ struct QuizView: View {
                     )
                     .padding(.horizontal, 16)
 
-                // Svarsknappar
                 LazyVGrid(columns: [GridItem(.flexible(), spacing: 20), GridItem(.flexible())], spacing: 20) {
                     ForEach(0..<4) { i in
                         AnswerButton(
                             index: i,
                             label: state.options[safe: i] ?? "",
-                            isCorrect: i == state.correctAnswerIndex,
-                            isSelected: state.isSelected(i),
                             showFeedback: state.showFeedback,
-                            onSelectAnswer: state.onSelectAnswer
+                            onSelectAnswer: state.onSelectAnswer,
+                            background: state.backgroundColor(for: i),
+                            foreground: state.foregroundColor(for: i),
+                            border: state.borderColor(for: i),
+                            badgeBackground: state.badgeBackground(for: i)
                         )
                         .frame(maxWidth: .infinity)
                         .frame(minHeight: 60)

--- a/SceneIt/Features/Quiz/QuizViewState.swift
+++ b/SceneIt/Features/Quiz/QuizViewState.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwiftUI
 
 struct QuizViewState {
     var question: String = ""
@@ -32,6 +32,34 @@ struct QuizViewState {
 
     var onSelectAnswer: (Int) -> Void = { _ in }
     var onNextQuestion: () -> Void = { }
+    
+    func backgroundColor(for index: Int) -> Color {
+        guard showFeedback else { return .clear }
+        if index == correctAnswerIndex { return Theme.correctBg.opacity(0.5) }
+        if index == selectedIndex { return Theme.wrongBg.opacity(0.5) }
+        return .clear
+    }
+    
+    func foregroundColor(for index: Int) -> Color {
+        guard showFeedback else { return Theme.text.opacity(0.85) }
+        if index == correctAnswerIndex { return Theme.correctText }
+        if index == selectedIndex { return Theme.wrongText }
+        return .white.opacity(0.4)
+    }
+    
+    func borderColor(for index: Int) -> Color {
+        guard showFeedback else { return Theme.highlight.opacity(0.3) }
+        if index == correctAnswerIndex { return Theme.correctText.opacity(0.4) }
+        if index == selectedIndex { return Theme.wrongText.opacity(0.4) }
+        return Theme.highlight.opacity(0.1)
+    }
+
+    func badgeBackground(for index: Int) -> Color {
+        guard showFeedback else { return Theme.primary }
+        if index == correctAnswerIndex { return Theme.correctBg }
+        if index == selectedIndex { return Theme.wrongBg }
+        return Theme.primary.opacity(0.3)
+    }
 
     static var preview: QuizViewState {
         var state = QuizViewState()


### PR DESCRIPTION
## Summary
Moved color calculation logic from `AnswerButton` (View) to `QuizViewState` to follow MVVM architecture.

## Changes
- Added `backgroundColor(for:)`, `foregroundColor(for:)`, `borderColor(for:)` and `badgeBackground(for:)` functions to `QuizViewState`
- Updated `QuizViewState` to use `import SwiftUI` instead of `import Foundation`
- Removed computed color properties from `AnswerButton`
- Replaced `isCorrect` and `isSelected` parameters in `AnswerButton` with ready-made `Color` values
- Updated `QuizView` to pass colors from `QuizViewState` to `AnswerButton`

## Why
- Color calculation is UI-logic that belongs in ViewState, not in the View
- View should only receive ready-made values and render them
- Follows the same MVVM pattern used across the rest of the project

## Result
`AnswerButton` is now pure layout — all color decisions are made in `QuizViewState` and passed down as ready-made `Color` values.