### PR TITLE
chore: extracted Array safe subscript extension to own file

### DIFF
--- a/SceneIt/Features/Quiz/Array+Safe.swift
+++ b/SceneIt/Features/Quiz/Array+Safe.swift
@@ -1,0 +1,5 @@
+extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -128,12 +128,6 @@ struct QuizView: View {
     }
 }
 
-extension Array {
-    subscript(safe index: Int) -> Element? {
-        indices.contains(index) ? self[index] : nil
-    }
-}
-
 #Preview {
     QuizView(viewModel: QuizViewModel(category: .comedy, onFinished: { _, _, _ in }))
 }


### PR DESCRIPTION
## Summary
Extracted `Array` safe subscript extension from `QuizView` into its own file.

## Changes
- Added `Array+Safe.swift` in `SceneIt/Features/Quiz/`
- Removed `extension Array` from `QuizView.swift`

## Why
- Extensions should not live inside View-files
- Follows Swift naming convention for extension files (`Type+Functionality.swift`)

## Result
`QuizView.swift` is cleaner and the extension is easier to find and reuse.