### PR TITLE
refactored: extracted question card into QuizQuestionCard component

### DIFF
--- a/SceneIt/Features/Quiz/QuizQuestionCard.swift
+++ b/SceneIt/Features/Quiz/QuizQuestionCard.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct QuizQuestionCard: View {
+    let question: String
+
+    var body: some View {
+        Text(question)
+            .font(.body)
+            .fontWeight(.semibold)
+            .foregroundStyle(Theme.text.opacity(0.85))
+            .multilineTextAlignment(.center)
+            .padding(.vertical, 24)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity)
+            .background(Color.clear)
+            .clipShape(OctagonShape(cut: 10))
+            .overlay(
+                ZStack {
+                    OctagonShape(cut: 10).stroke(
+                        Theme.highlight.opacity(0.4),
+                        lineWidth: 1.3
+                    )
+                    OctagonShape(cut: 10).inset(by: 8).stroke(
+                        Theme.highlight.opacity(0.3),
+                        lineWidth: 0.7
+                    )
+                    GeometryReader { geo in
+                        Path { p in
+                            p.move(to: CGPoint(x: geo.size.width * 0.3, y: 0))
+                            p.addLine(
+                                to: CGPoint(x: geo.size.width * 0.7, y: 0)
+                            )
+                        }
+                        .stroke(Theme.highlight.opacity(0.6), lineWidth: 2)
+                    }
+                    GeometryReader { geo in
+                        Path { p in
+                            p.move(to: CGPoint(x: 0, y: geo.size.height * 0.35))
+                            p.addLine(
+                                to: CGPoint(x: 0, y: geo.size.height * 0.45)
+                            )
+                        }
+                        .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
+                    }
+                    GeometryReader { geo in
+                        Path { p in
+                            p.move(
+                                to: CGPoint(
+                                    x: geo.size.width,
+                                    y: geo.size.height * 0.35
+                                )
+                            )
+                            p.addLine(
+                                to: CGPoint(
+                                    x: geo.size.width,
+                                    y: geo.size.height * 0.45
+                                )
+                            )
+                        }
+                        .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
+                    }
+                }
+            )
+            .padding(.horizontal, 16)
+    }
+}

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -51,44 +51,7 @@ struct QuizView: View {
                     .foregroundStyle(Theme.highlight.opacity(0.4))
                     .padding(.bottom, 48)
 
-                Text(state.question)
-                    .font(.body)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(Theme.text.opacity(0.85))
-                    .multilineTextAlignment(.center)
-                    .padding(.vertical, 24)
-                    .padding(.horizontal, 16)
-                    .frame(maxWidth: .infinity)
-                    .background(Color.clear)
-                    .clipShape(OctagonShape(cut: 10))
-                    .overlay(
-                        ZStack {
-                            OctagonShape(cut: 10).stroke(Theme.highlight.opacity(0.4), lineWidth: 1.3)
-                            OctagonShape(cut: 10).inset(by: 8).stroke(Theme.highlight.opacity(0.3), lineWidth: 0.7)
-                            GeometryReader { geo in
-                                Path { p in
-                                    p.move(to: CGPoint(x: geo.size.width * 0.3, y: 0))
-                                    p.addLine(to: CGPoint(x: geo.size.width * 0.7, y: 0))
-                                }
-                                .stroke(Theme.highlight.opacity(0.6), lineWidth: 2)
-                            }
-                            GeometryReader { geo in
-                                Path { p in
-                                    p.move(to: CGPoint(x: 0, y: geo.size.height * 0.35))
-                                    p.addLine(to: CGPoint(x: 0, y: geo.size.height * 0.45))
-                                }
-                                .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
-                            }
-                            GeometryReader { geo in
-                                Path { p in
-                                    p.move(to: CGPoint(x: geo.size.width, y: geo.size.height * 0.35))
-                                    p.addLine(to: CGPoint(x: geo.size.width, y: geo.size.height * 0.45))
-                                }
-                                .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
-                            }
-                        }
-                    )
-                    .padding(.horizontal, 16)
+                QuizQuestionCard(question: state.question)
 
                 LazyVGrid(columns: [GridItem(.flexible(), spacing: 20), GridItem(.flexible())], spacing: 20) {
                     ForEach(0..<4) { i in


### PR DESCRIPTION
## Summary
Extracted the question card from `QuizView` into its own reusable component.

## Changes
- Added `QuizQuestionCard.swift` in `SceneIt/Features/Quiz/`
- Removed inline question card code from `QuizView.swift`
- Replaced with `QuizQuestionCard(question: state.question)`

## Why
- `QuizView` was too large with layout details mixed in
- Extracting the card makes each file easier to read and maintain
- Follows the same pattern as `AnswerButton` and `DotsBackgroundView`

## Result
`QuizView` is cleaner and the question card is an isolated component with a single responsibility.