### PR TITLE
feat: redesigned ScoreCircleView with dual animated progress rings

### DIFF
--- a/SceneIt/Features/Result/ScoreCircleView.swift
+++ b/SceneIt/Features/Result/ScoreCircleView.swift
@@ -10,27 +10,56 @@ struct ScoreCircleView: View {
 
         ZStack {
 
-            ForEach([160.0, 145.0, 130.0], id: \.self) { radius in
-                Circle()
-                    .stroke(
-                        Theme.primary.opacity(0.07 + (160 - radius) * 0.005),
-                        lineWidth: 1
-                    )
-                    .frame(width: radius * 2, height: radius * 2)
-            }
+            Circle()
+                .stroke(
+                    state.progressColor.opacity(0.15),
+                    style: StrokeStyle(lineWidth: 1, lineCap: .round)
+                )
+                .frame(width: 320, height: 320)
 
             Circle()
                 .trim(from: 0, to: animateScore ? state.progress : 0)
                 .stroke(
                     state.progressColor,
-                    style: StrokeStyle(lineWidth: 8, lineCap: .round)
+                    style: StrokeStyle(lineWidth: 4, lineCap: .round)
                 )
-                .frame(width: 280, height: 280)
+                .frame(width: 300, height: 300)
                 .rotationEffect(.degrees(-90))
                 .animation(.easeInOut(duration: 0.8), value: animateScore)
-                .glowEffect(radius: 10)
+
+            Circle()
+                .stroke(
+                    state.progressColor.opacity(0.2),
+                    style: StrokeStyle(lineWidth: 1, lineCap: .round)
+                )
+                .frame(width: 280, height: 280)
+
+            Circle()
+                .stroke(
+                    state.progressColor.opacity(0.15),
+                    style: StrokeStyle(lineWidth: 1, lineCap: .round)
+                )
+                .frame(width: 258, height: 258)
+
+            Circle()
+                .trim(from: 0, to: animateScore ? state.progress : 0)
+                .stroke(
+                    state.progressColor.opacity(0.6),
+                    style: StrokeStyle(lineWidth: 4, lineCap: .round)
+                )
+                .frame(width: 246, height: 246)
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut(duration: 0.8), value: animateScore)
+
+            Circle()
+                .stroke(
+                    state.progressColor.opacity(0.2),
+                    style: StrokeStyle(lineWidth: 1, lineCap: .round)
+                )
+                .frame(width: 234, height: 234)
 
             VStack(spacing: 2) {
+
                 Text(state.scoreText)
                     .font(.system(size: 100, weight: .bold, design: .rounded))
                     .foregroundStyle(Theme.primary)
@@ -41,7 +70,6 @@ struct ScoreCircleView: View {
             }
 
             .frame(width: 320, height: 320)
-
         }
     }
 }
@@ -51,7 +79,11 @@ struct ScoreCircleView: View {
         Theme.bgGradient
             .ignoresSafeArea()
         ScoreCircleView(
-            state: ResultViewState(score: 8, totalQuestions: 10, category: .comedy),
+            state: ResultViewState(
+                score: 8,
+                totalQuestions: 10,
+                category: .comedy
+            ),
             animateScore: .constant(true)
         )
     }


### PR DESCRIPTION
## Summary
Redesigned `ScoreCircleView` with two concentric ring groups, each consisting of a progress arc framed by static track circles.

## Changes
- Replaced single progress arc and three decorative circles in `ScoreCircleView` with two independent animated progress arcs
- Added static track circles around each progress arc to create a visible outer and inner ring group
- Set outer progress arc (`P1`) to diameter 300px and inner progress arc (`P2`) to diameter 246px, each framed by two static circles

## Why
- The previous single arc gave no visual depth or structure to the score display
- Two ring groups with static track circles creates the layered, concentric design matching the intended result screen layout
- Prepares `ScoreCircleView` as a polished, self-contained component ready for final result screen integration

## Result
The result screen now displays two animated ring groups that fill simultaneously to the player's score percentage, with static circles framing each arc for a structured, layered visual design.