### PR TITLE
chore: moved hardcoded colors to assets

### DIFF
--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/Color.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/Color.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/CorrectBackground.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/CorrectBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x35",
+          "green" : "0x6B",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/CorrectText.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/CorrectText.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA8",
+          "green" : "0xFF",
+          "red" : "0x7E"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/WrongBackground.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/WrongBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1A",
+          "green" : "0x1A",
+          "red" : "0x6B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SceneIt/Core/Assets.xcassets/SceneIt Colors/WrongText.colorset/Contents.json
+++ b/SceneIt/Core/Assets.xcassets/SceneIt Colors/WrongText.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xAA",
+          "green" : "0xAA",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SceneIt/Core/Theme.swift
+++ b/SceneIt/Core/Theme.swift
@@ -9,14 +9,14 @@ struct Theme {
     static let primary = Color("SceneIt Colors/Primary")
     static let accent = Color("SceneIt Colors/Accent")
     static let highlight = Color("SceneIt Colors/Highlight")
-    static let text        = Color("SceneIt Colors/Text")
-    
+    static let text = Color("SceneIt Colors/Text")
+
     // ====== Feedback colors ======
 
-    static let correctBg = Color(hex: "1A6B35")
-    static let correctText = Color(hex: "7EFFA8")
-    static let wrongBg = Color(hex: "6B1A1A")
-    static let wrongText = Color(hex: "FFAAAA")
+    static let correctBg = Color("SceneIt Colors/CorrectBackground")
+    static let correctText = Color("SceneIt Colors/CorrectText")
+    static let wrongBg = Color("SceneIt Colors/WrongBackground")
+    static let wrongText = Color("SceneIt Colors/WrongText")
 
     // ====== Gradients ======
 
@@ -42,34 +42,6 @@ struct Theme {
         endPoint: .trailing
     )
 
-    // ====== Glow ======
-
-    static func glow(radius: CGFloat = 10) -> some ViewModifier {
-        GlowModifier(color: Color("SceneIt Colors/Highlight"), radius: radius)
-    }
-}
-
-// ====== Glow modifier ======
-
-struct GlowModifier: ViewModifier {
-    let color: Color
-    let radius: CGFloat
-    func body(content: Content) -> some View {
-        content.shadow(color: color.opacity(0.4), radius: radius)
-    }
-}
-
-// ====== View extension ======
-
-extension View {
-    func glowEffect(radius: CGFloat = 10) -> some View {
-        modifier(
-            GlowModifier(
-                color: Color("SceneIt Colors/Highlight"),
-                radius: radius
-            )
-        )
-    }
 }
 
 // ====== Hex color helper ======


### PR DESCRIPTION
## Summary
Moved hardcoded colors to Assets and cleaned up unused code in Theme.

## Changes
- Added `CorrectBackground`, `CorrectText`, `WrongBackground`, `WrongText` to `Assets.xcassets`
- Updated `Theme.swift` to reference new asset colors instead of hardcoded hex values
- Updated `DotsBackgroundView` to use `Theme.highlight` instead of hardcoded hex color
- Removed unused `GlowModifier`, `Theme.glow()` and `glowEffect()` extension
- Removed unused `progressGradient` from `Theme.swift`

## Why
- Hardcoded hex colors should live in Assets for consistency and easy theming
- Unused code adds noise and should be removed

## Result
All colors are now defined in Assets and Theme has no unused code.