### PR TITLE
Feature/quiz gradient progress bar

### DIFF
--- a/SceneIt/Core/Theme.swift
+++ b/SceneIt/Core/Theme.swift
@@ -44,6 +44,16 @@ struct Theme {
 
 }
 
+// ====== Glow modifier ======
+
+struct GlowModifier: ViewModifier {
+    let color: Color
+    let radius: CGFloat
+    func body(content: Content) -> some View {
+        content.shadow(color: color.opacity(0.4), radius: radius)
+    }
+}
+
 // ====== Hex color helper ======
 
 extension Color {

--- a/SceneIt/Features/Quiz/ProgressBar.swift
+++ b/SceneIt/Features/Quiz/ProgressBar.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ProgressBar: View {
+    let progress: Double
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Theme.highlight.opacity(0.15))
+                    .frame(height: 4)
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Theme.progressGradient)
+                    .frame(width: geo.size.width * progress, height: 4)
+                    .animation(.easeInOut, value: progress)
+            }
+        }
+        .frame(height: 4)
+    }
+}

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -34,8 +34,7 @@ struct QuizView: View {
                 .padding(.horizontal)
                 .padding(.top, 60)
 
-                ProgressView(value: state.progress)
-                    .tint(Theme.primary)
+                ProgressBar(progress: state.progress)
                     .padding(.horizontal)
                     .padding(.top, 8)
 


### PR DESCRIPTION
## Summary
Replaced the default ProgressView with a custom gradient progress bar in the quiz screen and restored GlowModifier.

## Changes
- Added `ProgressBar.swift` in `SceneIt/Features/Quiz/`
- Replaced `ProgressView` with `ProgressBar` in `QuizView`
- Restored `GlowModifier` in `Theme.swift` used by `CategoryCard`

## Why
- `ProgressView` does not support gradients via `.tint`
- The custom bar uses `Theme.progressGradient` for a more polished look consistent with the app design
- `GlowModifier` was accidentally removed in a previous PR but is still needed by `CategoryCard`

## Result
The quiz progress bar now displays a gradient matching the app's visual style, and `CategoryCard` glow works correctly again.