### PR TITLE
chore: replaced hardcoded values with design constants in quiz files

### DIFF
--- a/SceneIt/Core/Constants.swift
+++ b/SceneIt/Core/Constants.swift
@@ -1,6 +1,7 @@
 import CoreFoundation
 
 enum Spacing {
+    static let none: CGFloat = 0
     static let xxxSmall: CGFloat = 2
     static let xxSmall: CGFloat = 4
     static let xSmall: CGFloat = 6
@@ -45,6 +46,11 @@ enum Layout {
     static let scoreContainerSize: CGFloat = 320
     static let glowRadius: CGFloat = 10
     static let glowRadiusSelected: CGFloat = 12
+    static let progressBarHeight: CGFloat = 4
+    static let progressBarCornerRadius: CGFloat = 4
+    static let previewLineWidth: CGFloat = 1.5
+    static let previewFrameWidth: CGFloat = 300
+    static let previewFrameHeight: CGFloat = 120
 }
 
 enum FontSize {
@@ -61,8 +67,11 @@ enum FontSize {
 }
 
 enum Opacity {
+    static let none: Double = 0.0
     static let dots: Double = 0.08
+    static let faintest: Double = 0.15
     static let faint: Double = 0.2
+    static let ghost: Double = 0.1
     static let disabled: Double = 0.3
     static let subtle: Double = 0.35
     static let medium: Double = 0.4
@@ -72,6 +81,8 @@ enum Opacity {
     static let strong: Double = 0.8
     static let high: Double = 0.85
     static let almostFull: Double = 0.9
+    static let full: Double = 1.0
+
 }
 
 enum AnimationDuration {
@@ -84,3 +95,15 @@ enum Tracking {
     static let wide: CGFloat = 3
     static let lineSpacing: CGFloat = 4
 }
+
+enum Quiz {
+    static let answerLineLimit: Int = 3
+}
+
+enum OctagonDecoration {
+    static let topLineStart: CGFloat = 0.3
+    static let topLineEnd: CGFloat = 0.7
+    static let sideLineStart: CGFloat = 0.35
+    static let sideLineEnd: CGFloat = 0.45
+}
+

--- a/SceneIt/Core/OctagonShape.swift
+++ b/SceneIt/Core/OctagonShape.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct OctagonShape: Shape, InsettableShape {
-    var cut: CGFloat = 20
-    var insetAmount: CGFloat = 0
+    var cut: CGFloat = Layout.octagonCut
+    var insetAmount: CGFloat = Spacing.none
 
     func path(in rect: CGRect) -> Path {
         let cut = self.cut
@@ -29,7 +29,7 @@ struct OctagonShape: Shape, InsettableShape {
 
 #Preview {
     OctagonShape()
-        .stroke(Color.red, lineWidth: 1.5)
-        .frame(width: 300, height: 120)
+        .stroke(Color.red, lineWidth: Layout.previewLineWidth)
+        .frame(width: Layout.previewFrameWidth, height: Layout.previewFrameHeight)
         .padding()
 }

--- a/SceneIt/Features/Quiz/AnswerButton.swift
+++ b/SceneIt/Features/Quiz/AnswerButton.swift
@@ -6,19 +6,19 @@ struct AnswerButton: View {
     let showFeedback: Bool
     let onSelectAnswer: (Int) -> Void
 
-    private let letters = ["A", "B", "C", "D"]
-    private var letter: String { letters[index] }
-
     let background: Color
     let foreground: Color
     let border: Color
     let badgeBackground: Color
 
+    private let letters = ["A", "B", "C", "D"]
+    private var letter: String { letters[index] }
+
     var body: some View {
         Button {
             onSelectAnswer(index)
         } label: {
-            HStack(spacing: 0) {
+            HStack(spacing: Spacing.none) {
 
                 if index % 2 == 0 {
                     badgeView
@@ -26,16 +26,16 @@ struct AnswerButton: View {
                         .font(.caption)
                         .fontWeight(.semibold)
                         .foregroundStyle(foreground)
-                        .lineLimit(3)
-                        .padding(.horizontal, 8)
+                        .lineLimit(Quiz.answerLineLimit)
+                        .padding(.horizontal, Spacing.small)
                         .frame(maxWidth: .infinity)
                 } else {
                     Text(label)
                         .font(.caption)
                         .fontWeight(.semibold)
                         .foregroundStyle(foreground)
-                        .lineLimit(3)
-                        .padding(.horizontal, 8)
+                        .lineLimit(Quiz.answerLineLimit)
+                        .padding(.horizontal, Spacing.small)
                         .frame(maxWidth: .infinity)
                     badgeView
                 }
@@ -43,19 +43,19 @@ struct AnswerButton: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(background)
-        .cornerRadius(10)
+        .cornerRadius(Layout.cornerRadius)
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(border, lineWidth: 1)
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(border, lineWidth: Layout.borderWidth)
         )
         .disabled(showFeedback)
     }
 
     private var badgeView: some View {
         Text(letter)
-            .font(.system(size: 10, weight: .bold))
-            .foregroundStyle(.white.opacity(0.85))
-            .frame(width: 24)
+            .font(.system(size: FontSize.xSmall, weight: .bold))
+            .foregroundStyle(.white.opacity(Opacity.high))
+            .frame(width: Layout.badgeWidth)
             .frame(maxHeight: .infinity)
             .background(badgeBackground)
     }

--- a/SceneIt/Features/Quiz/ProgressBar.swift
+++ b/SceneIt/Features/Quiz/ProgressBar.swift
@@ -6,15 +6,15 @@ struct ProgressBar: View {
     var body: some View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Theme.highlight.opacity(0.15))
-                    .frame(height: 4)
-                RoundedRectangle(cornerRadius: 4)
+                RoundedRectangle(cornerRadius: Layout.progressBarCornerRadius)
+                    .fill(Theme.highlight.opacity(Opacity.faintest))
+                    .frame(height: Layout.progressBarHeight)
+                RoundedRectangle(cornerRadius: Layout.progressBarCornerRadius)
                     .fill(Theme.progressGradient)
-                    .frame(width: geo.size.width * progress, height: 4)
+                    .frame(width: geo.size.width * progress, height: Layout.progressBarHeight)
                     .animation(.easeInOut, value: progress)
             }
         }
-        .frame(height: 4)
+        .frame(height: Layout.progressBarHeight)
     }
 }

--- a/SceneIt/Features/Quiz/QuizQuestionCard.swift
+++ b/SceneIt/Features/Quiz/QuizQuestionCard.swift
@@ -7,60 +7,93 @@ struct QuizQuestionCard: View {
         Text(question)
             .font(.body)
             .fontWeight(.semibold)
-            .foregroundStyle(Theme.text.opacity(0.85))
+            .foregroundStyle(Theme.text.opacity(Opacity.high))
             .multilineTextAlignment(.center)
-            .padding(.vertical, 24)
-            .padding(.horizontal, 16)
+            .padding(.vertical, Spacing.xxxLarge)
+            .padding(.horizontal, Spacing.large)
             .frame(maxWidth: .infinity)
             .background(Color.clear)
-            .clipShape(OctagonShape(cut: 10))
+            .clipShape(OctagonShape(cut: Layout.octagonCut))
             .overlay(
                 ZStack {
-                    OctagonShape(cut: 10).stroke(
-                        Theme.highlight.opacity(0.4),
-                        lineWidth: 1.3
+                    OctagonShape(cut: Layout.octagonCut).stroke(
+                        Theme.highlight.opacity(Opacity.medium),
+                        lineWidth: Layout.octagonStroke
                     )
-                    OctagonShape(cut: 10).inset(by: 8).stroke(
-                        Theme.highlight.opacity(0.3),
-                        lineWidth: 0.7
+                    OctagonShape(cut: Layout.octagonCut).inset(
+                        by: Layout.octagonInset
+                    ).stroke(
+                        Theme.highlight.opacity(Opacity.disabled),
+                        lineWidth: Layout.octagonInsetStroke
                     )
                     GeometryReader { geo in
                         Path { p in
-                            p.move(to: CGPoint(x: geo.size.width * 0.3, y: 0))
+                            p.move(
+                                to: CGPoint(
+                                    x: geo.size.width
+                                        * OctagonDecoration.topLineStart,
+                                    y: Spacing.none
+                                )
+                            )
                             p.addLine(
-                                to: CGPoint(x: geo.size.width * 0.7, y: 0)
+                                to: CGPoint(
+                                    x: geo.size.width
+                                        * OctagonDecoration.topLineEnd,
+                                    y: Spacing.none
+                                )
                             )
                         }
-                        .stroke(Theme.highlight.opacity(0.6), lineWidth: 2)
+                        .stroke(
+                            Theme.highlight.opacity(Opacity.muted),
+                            lineWidth: Layout.borderWidthSelected
+                        )
                     }
                     GeometryReader { geo in
                         Path { p in
-                            p.move(to: CGPoint(x: 0, y: geo.size.height * 0.35))
+                            p.move(
+                                to: CGPoint(
+                                    x: Spacing.none,
+                                    y: geo.size.height
+                                        * OctagonDecoration.sideLineStart
+                                )
+                            )
                             p.addLine(
-                                to: CGPoint(x: 0, y: geo.size.height * 0.45)
+                                to: CGPoint(
+                                    x: Spacing.none,
+                                    y: geo.size.height
+                                        * OctagonDecoration.sideLineEnd
+                                )
                             )
                         }
-                        .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
+                        .stroke(
+                            Theme.highlight.opacity(Opacity.disabled),
+                            lineWidth: Layout.octagonLineStroke
+                        )
                     }
                     GeometryReader { geo in
                         Path { p in
                             p.move(
                                 to: CGPoint(
                                     x: geo.size.width,
-                                    y: geo.size.height * 0.35
+                                    y: geo.size.height
+                                        * OctagonDecoration.sideLineStart
                                 )
                             )
                             p.addLine(
                                 to: CGPoint(
                                     x: geo.size.width,
-                                    y: geo.size.height * 0.45
+                                    y: geo.size.height
+                                        * OctagonDecoration.sideLineEnd
                                 )
                             )
                         }
-                        .stroke(Theme.highlight.opacity(0.3), lineWidth: 1.2)
+                        .stroke(
+                            Theme.highlight.opacity(Opacity.disabled),
+                            lineWidth: Layout.octagonLineStroke
+                        )
                     }
                 }
             )
-            .padding(.horizontal, 16)
+            .padding(.horizontal, Spacing.large)
     }
 }

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -9,50 +9,65 @@ struct QuizView: View {
         ZStack {
             Theme.bgGradient
                 .ignoresSafeArea()
-            
+
             DotsBackgroundView()
 
-            VStack(spacing: 0) {
+            VStack(spacing: Spacing.none) {
 
                 HStack {
                     Text(state.questionLabel)
                         .font(.caption)
-                        .foregroundStyle(Theme.highlight.opacity(0.4))
+                        .foregroundStyle(
+                            Theme.highlight.opacity(Opacity.medium)
+                        )
                     Spacer()
                     Text(state.scoreLabel)
                         .font(.caption)
-                        .foregroundStyle(Theme.highlight.opacity(0.9))
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 4)
-                        .background(Theme.primary.opacity(0.2))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(Theme.highlight.opacity(0.2), lineWidth: 1)
+                        .foregroundStyle(
+                            Theme.highlight.opacity(Opacity.almostFull)
                         )
-                        .cornerRadius(12)
+                        .padding(.horizontal, Spacing.medium)
+                        .padding(.vertical, Spacing.xxSmall)
+                        .background(Theme.primary.opacity(Opacity.faint))
+                        .overlay(
+                            RoundedRectangle(
+                                cornerRadius: Layout.cornerRadiusMedium
+                            )
+                            .stroke(
+                                Theme.highlight.opacity(Opacity.faint),
+                                lineWidth: Layout.borderWidth
+                            )
+                        )
+                        .cornerRadius(Layout.cornerRadiusMedium)
                 }
                 .padding(.horizontal)
-                .padding(.top, 60)
+                .padding(.top, Spacing.xxHuge)
 
                 ProgressBar(progress: state.progress)
                     .padding(.horizontal)
-                    .padding(.top, 8)
+                    .padding(.top, Spacing.small)
 
                 Spacer()
 
                 Text(state.seriesName.uppercased())
                     .font(.headline)
                     .fontWeight(.semibold)
-                    .foregroundStyle(Theme.highlight.opacity(0.5))
+                    .foregroundStyle(Theme.highlight.opacity(Opacity.half))
                 Text(state.categoryName.uppercased())
                     .font(.caption)
                     .fontWeight(.semibold)
-                    .foregroundStyle(Theme.highlight.opacity(0.4))
-                    .padding(.bottom, 48)
+                    .foregroundStyle(Theme.highlight.opacity(Opacity.medium))
+                    .padding(.bottom, Spacing.xHuge)
 
                 QuizQuestionCard(question: state.question)
 
-                LazyVGrid(columns: [GridItem(.flexible(), spacing: 20), GridItem(.flexible())], spacing: 20) {
+                LazyVGrid(
+                    columns: [
+                        GridItem(.flexible(), spacing: Spacing.xLarge),
+                        GridItem(.flexible()),
+                    ],
+                    spacing: Spacing.xLarge
+                ) {
                     ForEach(0..<4) { i in
                         AnswerButton(
                             index: i,
@@ -65,11 +80,11 @@ struct QuizView: View {
                             badgeBackground: state.badgeBackground(for: i)
                         )
                         .frame(maxWidth: .infinity)
-                        .frame(minHeight: 60)
+                        .frame(minHeight: Layout.buttonHeight)
                     }
                 }
-                .padding(.horizontal, 16)
-                .padding(.top, 60)
+                .padding(.horizontal, Spacing.large)
+                .padding(.top, Spacing.xxHuge)
 
                 Spacer()
 
@@ -80,8 +95,10 @@ struct QuizView: View {
                 .padding()
                 .background(Theme.buttonGradient)
                 .foregroundStyle(.white)
-                .cornerRadius(28)
-                .opacity(state.isNextButtonVisible ? 1.0 : 0.0)
+                .cornerRadius(Layout.cornerRadiusButton)
+                .opacity(
+                    state.isNextButtonVisible ? Opacity.full : Opacity.none
+                )
                 .disabled(state.isNextButtonDisabled)
                 .padding(.horizontal)
                 .padding(.bottom)
@@ -91,5 +108,7 @@ struct QuizView: View {
 }
 
 #Preview {
-    QuizView(viewModel: QuizViewModel(category: .comedy, onFinished: { _, _, _ in }))
+    QuizView(
+        viewModel: QuizViewModel(category: .comedy, onFinished: { _, _, _ in })
+    )
 }

--- a/SceneIt/Features/Quiz/QuizViewState.swift
+++ b/SceneIt/Features/Quiz/QuizViewState.swift
@@ -32,44 +32,32 @@ struct QuizViewState {
 
     var onSelectAnswer: (Int) -> Void = { _ in }
     var onNextQuestion: () -> Void = { }
-    
+
     func backgroundColor(for index: Int) -> Color {
         guard showFeedback else { return .clear }
-        if index == correctAnswerIndex { return Theme.correctBg.opacity(0.5) }
-        if index == selectedIndex { return Theme.wrongBg.opacity(0.5) }
+        if index == correctAnswerIndex { return Theme.correctBg.opacity(Opacity.half) }
+        if index == selectedIndex { return Theme.wrongBg.opacity(Opacity.half) }
         return .clear
     }
-    
+
     func foregroundColor(for index: Int) -> Color {
-        guard showFeedback else { return Theme.text.opacity(0.85) }
+        guard showFeedback else { return Theme.text.opacity(Opacity.high) }
         if index == correctAnswerIndex { return Theme.correctText }
         if index == selectedIndex { return Theme.wrongText }
-        return .white.opacity(0.4)
+        return .white.opacity(Opacity.medium)
     }
-    
+
     func borderColor(for index: Int) -> Color {
-        guard showFeedback else { return Theme.highlight.opacity(0.3) }
-        if index == correctAnswerIndex { return Theme.correctText.opacity(0.4) }
-        if index == selectedIndex { return Theme.wrongText.opacity(0.4) }
-        return Theme.highlight.opacity(0.1)
+        guard showFeedback else { return Theme.highlight.opacity(Opacity.disabled) }
+        if index == correctAnswerIndex { return Theme.correctText.opacity(Opacity.medium) }
+        if index == selectedIndex { return Theme.wrongText.opacity(Opacity.medium) }
+        return Theme.highlight.opacity(Opacity.ghost)
     }
 
     func badgeBackground(for index: Int) -> Color {
         guard showFeedback else { return Theme.primary }
         if index == correctAnswerIndex { return Theme.correctBg }
         if index == selectedIndex { return Theme.wrongBg }
-        return Theme.primary.opacity(0.3)
-    }
-
-    static var preview: QuizViewState {
-        var state = QuizViewState()
-        state.question = "Vilket år hade serien Solsidan premiär på TV4?"
-        state.options = ["2008", "2010", "2012", "2014"]
-        state.correctAnswerIndex = 2
-        state.progress = 0.4
-        state.score = 3
-        state.currentIndex = 3
-        state.categoryName = "Svenska Serier"
-        return state
+        return Theme.primary.opacity(Opacity.disabled)
     }
 }


### PR DESCRIPTION
## Summary
Replaced all hardcoded numeric values in quiz files with shared design constants.

## Changes
- Updated `Constants.swift` with new constants (`Opacity.ghost`, `Opacity.none`, `Opacity.full`, `Opacity.faintest`, `Layout.progressBarHeight`, `Layout.progressBarCornerRadius`, `Layout.previewLineWidth`, `Layout.previewFrameWidth`, `Layout.previewFrameHeight`, `Quiz.answerLineLimit`, `OctagonDecoration`)
- Updated `QuizView.swift` to use constants
- Updated `QuizViewState.swift` to use constants
- Updated `QuizQuestionCard.swift` to use constants
- Updated `AnswerButton.swift` to use constants
- Updated `ProgressBar.swift` to use constants
- Updated `OctagonShape.swift` to use constants

## Why
- Hardcoded values were scattered across quiz files
- All values should reference shared constants for consistency across the team

## Result
All quiz files are now free from hardcoded values and reference `Constants.swift` instead.