### PR TITLE
Refactor/remove category series hardcoded list

### DIFF
--- a/SceneIt/Models/Category.swift
+++ b/SceneIt/Models/Category.swift
@@ -15,14 +15,6 @@ enum Category: String, Codable, CaseIterable {
         }
     }
 
-    var series: [String] {
-        switch self {
-        case .comedy: return ["Solsidan", "Bonusfamiljen", "Svensson Svensson"]
-        case .thriller: return ["Johan Falk", "Beck", "Veronika"]
-        case .drama: return ["Störst av allt", "Knutby", "Tunna blå linjen"]
-        case .action: return ["Snabba Cash", "Gåsmamman", "Jägarna"]
-        }
-    }
 }
 
 struct CategoryItem: Identifiable {

--- a/SceneIt/Models/QuestionStore.swift
+++ b/SceneIt/Models/QuestionStore.swift
@@ -35,4 +35,11 @@ final class QuestionStore {
             .map { $0 }
     }
 
+    func series(for category: Category) -> [String] {
+        let names = allQuestions
+            .filter { $0.category == category }
+            .map { $0.series }
+        return Array(Set(names)).sorted()
+    }
+
 }


### PR DESCRIPTION
## Summary
Removed hardcoded `Category.series` and replaced it with a `series(for:)`
method in `QuestionStore` that derives unique series names directly from JSON data.

## Changes
- Removed hardcoded `series` property from `Category` enum
- Added `series(for:)` to `QuestionStore` filtering unique series names
  from `allQuestions` sorted alphabetically

## Why
- `Category.series` was a hardcoded duplicate of data already in `questions.json`
- `QuestionStore` becomes the single source of truth for all question-related data
- Prepares series data to be dynamically available anywhere `QuestionStore` is used

## Result
Series names are now derived directly from JSON through
`QuestionStore.shared.series(for:)` with no hardcoded values in the model layer.