### PR TITLE
fix: reset selected category when restarting the game

### DIFF
--- a/SceneIt/AppViewModel.swift
+++ b/SceneIt/AppViewModel.swift
@@ -7,32 +7,26 @@ enum AppScreen {
     case result(score: Int, total: Int, category: Category)
 }
 
-
 @MainActor
 final class AppViewModel: ObservableObject {
-
     
     @Published var screen: AppScreen = .start
-
-   
+    
     @Published private(set) var startViewModel: StartViewModel
     @Published private(set) var quizViewModel: QuizViewModel?
     @Published private(set) var resultViewModel: ResultViewModel?
-
+    
     init() {
-        
         startViewModel = StartViewModel()
         startViewModel.onStart = { [weak self] category in
             self?.startQuiz(category: category)
         }
     }
-
     
     func startQuiz(category: Category) {
         quizViewModel = QuizViewModel(category: category, onFinished: showResult)
         screen = .quiz(category: category)
     }
-
     
     func showResult(score: Int, total: Int, category: Category) {
         resultViewModel = ResultViewModel(
@@ -43,11 +37,11 @@ final class AppViewModel: ObservableObject {
         )
         screen = .result(score: score, total: total, category: category)
     }
-
     
     func restart() {
         resultViewModel = nil
         quizViewModel = nil
+        startViewModel.reset()
         screen = .start
     }
 }

--- a/SceneIt/Features/Start/StartViewModel.swift
+++ b/SceneIt/Features/Start/StartViewModel.swift
@@ -8,6 +8,8 @@ final class StartViewModel: ObservableObject {
     
     var onStart: ((Category) -> Void)?
     
+    func reset() {state.selectedCategory = nil }
+    
     init() {
         state.onSelectCategory = { [weak self] category in
             self?.state.selectedCategory = category


### PR DESCRIPTION
**Summary**
Fixed a bug where the previously selected category persisted when restarting the game from the result screen.

**Changes**
- Added reset() to StartViewModel: Created a new method to nullify the selectedCategory.
- Updated AppViewModel: Integrated a call to startViewModel.reset() inside the restart() function.
- Cleared Selection State: Ensured the start menu returns to its initial state (no category selected) when playing again.

**Why**
- Bug Fix: Prevented the "Start" button from appearing immediately upon returning to the menu.
- UX Improvement: Ensures a fresh start for the user, requiring a new category selection for each new game session.

**Result**
- When clicking "Play Again" on the result page, the user now returns to a clean start menu with no pre-selected category.
- The Start button is hidden until a new selection is made, as intended.