### PR TITLE
feat: added slide animation between quiz questions

### DIFF
--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -59,32 +59,40 @@ struct QuizView: View {
                     .foregroundStyle(Theme.highlight.opacity(Opacity.medium))
                     .padding(.bottom, Spacing.xHuge)
 
-                QuizQuestionCard(question: state.question)
+                VStack(spacing: Spacing.xxHuge) {
+                    QuizQuestionCard(question: state.question)
 
-                LazyVGrid(
-                    columns: [
-                        GridItem(.flexible(), spacing: Spacing.xLarge),
-                        GridItem(.flexible()),
-                    ],
-                    spacing: Spacing.xLarge
-                ) {
-                    ForEach(0..<4) { i in
-                        AnswerButton(
-                            index: i,
-                            label: state.options[safe: i] ?? "",
-                            showFeedback: state.showFeedback,
-                            onSelectAnswer: state.onSelectAnswer,
-                            background: state.backgroundColor(for: i),
-                            foreground: state.foregroundColor(for: i),
-                            border: state.borderColor(for: i),
-                            badgeBackground: state.badgeBackground(for: i)
-                        )
-                        .frame(maxWidth: .infinity)
-                        .frame(minHeight: Layout.buttonHeight)
+                    LazyVGrid(
+                        columns: [
+                            GridItem(.flexible(), spacing: Spacing.xLarge),
+                            GridItem(.flexible()),
+                        ],
+                        spacing: Spacing.xLarge
+                    ) {
+                        ForEach(0..<4) { i in
+                            AnswerButton(
+                                index: i,
+                                label: state.options[safe: i] ?? "",
+                                showFeedback: state.showFeedback,
+                                onSelectAnswer: state.onSelectAnswer,
+                                background: state.backgroundColor(for: i),
+                                foreground: state.foregroundColor(for: i),
+                                border: state.borderColor(for: i),
+                                badgeBackground: state.badgeBackground(for: i)
+                            )
+                            .frame(maxWidth: .infinity)
+                            .frame(minHeight: Layout.buttonHeight)
+                        }
                     }
+                    .padding(.horizontal, Spacing.large)
                 }
-                .padding(.horizontal, Spacing.large)
-                .padding(.top, Spacing.xxHuge)
+                .id(state.currentIndex)
+                .transition(.asymmetric(
+                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                    removal: .move(edge: .leading).combined(with: .opacity)
+                ))
+                .animation(.easeInOut(duration: 0.3), value: state.currentIndex)
+                .clipped()
 
                 Spacer()
 

--- a/SceneIt/Features/Quiz/QuizViewModel.swift
+++ b/SceneIt/Features/Quiz/QuizViewModel.swift
@@ -1,5 +1,5 @@
 import Combine
-import Foundation
+import SwiftUI
 
 @MainActor
 final class QuizViewModel: ObservableObject {
@@ -31,8 +31,10 @@ final class QuizViewModel: ObservableObject {
     }
 
     private func nextQuestion() {
-        state.currentIndex += 1
         state.selectedIndex = nil
+        withAnimation(.easeInOut(duration: 0.3)) {
+            state.currentIndex += 1
+        }
         guard state.currentIndex < questions.count else {
             onFinished(state.score, state.total, category)
             return


### PR DESCRIPTION
## Summary
Added a slide transition between quiz questions for a smoother user experience.

## Changes
- Wrapped question card and answer buttons in a shared `VStack` with `.id(state.currentIndex)` to trigger transition
- Added asymmetric slide transition — old question slides out to the left, new slides in from the right
- Added `withAnimation` in `QuizViewModel.nextQuestion()` to drive the animation
- Imported `SwiftUI` in `QuizViewModel`

## Why
- Jumping between questions felt abrupt with no visual feedback
- A slide animation gives a clear sense of progression through the quiz

## Result
Questions now slide smoothly in from the right and out to the left when the user moves to the next question.