### PR TITLE
feat: added high score persistence and display in result screen

### DIFF
--- a/SceneIt/AppViewModel.swift
+++ b/SceneIt/AppViewModel.swift
@@ -29,6 +29,7 @@ final class AppViewModel: ObservableObject {
     }
     
     func showResult(score: Int, total: Int, category: Category) {
+        HighScoreStore.shared.save(score: score, for: category)
         resultViewModel = ResultViewModel(
             score: score,
             totalQuestions: total,

--- a/SceneIt/Core/Localizable.xcstrings
+++ b/SceneIt/Core/Localizable.xcstrings
@@ -75,6 +75,28 @@
         }
       }
     },
+    "highscore_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bästa resultat: %lld/%lld"
+          }
+        }
+      }
+    },
+    "new_highscore_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nytt rekord!"
+          }
+        }
+      }
+    },
     "next_button" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/SceneIt/Features/Result/ResultView.swift
+++ b/SceneIt/Features/Result/ResultView.swift
@@ -60,6 +60,17 @@ struct ResultView: View {
                             animateScore = true
                         }
                         .padding(.bottom, Spacing.xxxxLarge)
+                    
+                    if state.isNewHighScore {
+                        Text(state.newHighScoreLabel)
+                            .font(.caption)
+                            .fontWeight(.bold)
+                            .foregroundStyle(Theme.highlight)
+                    } else if let label = state.highScoreLabel {
+                        Text(label)
+                            .font(.caption)
+                            .foregroundStyle(Theme.highlight.opacity(Opacity.half))
+                    }
 
                     DividerView()
                         .padding(.bottom, Spacing.large)

--- a/SceneIt/Features/Result/ResultViewState.swift
+++ b/SceneIt/Features/Result/ResultViewState.swift
@@ -45,6 +45,20 @@ struct ResultViewState {
         guard totalQuestions > 0 else { return 0 }
         return Double(score) / Double(totalQuestions)
     }
+    
+    var highScore: Int? { HighScoreStore.shared.highScore(for: category) }
+    
+    var newHighScoreLabel: String { String(localized: "new_highscore_label") }
+    
+    var highScoreLabel: String? {
+        guard let hs = HighScoreStore.shared.highScore(for: category) else { return nil }
+        return "Bästa resultat: \(hs)/\(totalQuestions)"
+    }
+
+    var isNewHighScore: Bool {
+        guard let hs = HighScoreStore.shared.highScore(for: category) else { return true }
+        return score >= hs
+    }
 
     var resultHeadLine: String {
         switch score {

--- a/SceneIt/Models/HighScoreStore.swift
+++ b/SceneIt/Models/HighScoreStore.swift
@@ -1,0 +1,23 @@
+
+import Foundation
+
+final class HighScoreStore {
+    static let shared = HighScoreStore()
+    private let defaults = UserDefaults.standard
+
+    private init() {}
+
+    func highScore(for category: Category) -> Int? {
+        let key = "highscore_\(category.rawValue)"
+        guard defaults.object(forKey: key) != nil else { return nil }
+        return defaults.integer(forKey: key)
+    }
+
+    func save(score: Int, for category: Category) {
+        let key = "highscore_\(category.rawValue)"
+        let current = highScore(for: category) ?? 0
+        if score > current {
+            defaults.set(score, forKey: key)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Added high score persistence so the best result per category is saved and shown on the result screen.

## Changes
- Added `HighScoreStore.swift` in `SceneIt/Models/` using `UserDefaults`
- Updated `AppViewModel` to save score via `HighScoreStore` when quiz is finished
- Added `highScoreLabel`, `newHighScoreLabel` and `isNewHighScore` to `ResultViewState`
- Updated `ResultView` to show high score or new record label
- Added `highscore_label` and `new_highscore_label` keys to `Localizable.xcstrings`

## Why
- Users should be able to track their best result per category
- Gives motivation to replay and improve

## Result
The best score per category is saved and shown on the result screen. A special message is shown when the user sets a new record.