### PR TITLE
fix: replaced hardcoded animation duration 

### DIFF
--- a/SceneIt/Core/Constants.swift
+++ b/SceneIt/Core/Constants.swift
@@ -93,6 +93,7 @@ enum Opacity {
 
 enum AnimationDuration {
     static let fast: Double = 0.2
+    static let transition: Double = 0.3
     static let score: Double = 0.8
 }
 

--- a/SceneIt/Features/Quiz/QuizView.swift
+++ b/SceneIt/Features/Quiz/QuizView.swift
@@ -91,7 +91,7 @@ struct QuizView: View {
                     insertion: .move(edge: .trailing).combined(with: .opacity),
                     removal: .move(edge: .leading).combined(with: .opacity)
                 ))
-                .animation(.easeInOut(duration: 0.3), value: state.currentIndex)
+                .animation(.easeInOut(duration: AnimationDuration.transition), value: state.currentIndex)
                 .clipped()
 
                 Spacer()

--- a/SceneIt/Features/Quiz/QuizViewModel.swift
+++ b/SceneIt/Features/Quiz/QuizViewModel.swift
@@ -32,7 +32,7 @@ final class QuizViewModel: ObservableObject {
 
     private func nextQuestion() {
         state.selectedIndex = nil
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(.easeInOut(duration: AnimationDuration.transition)) {
             state.currentIndex += 1
         }
         guard state.currentIndex < questions.count else {


### PR DESCRIPTION
# Summary
Replaced hardcoded animation duration with a named constant.

## Changes
- Added `AnimationDuration.transition` to `Constants.swift`
- Updated `QuizView.swift` to use `AnimationDuration.transition`
- Updated `QuizViewModel.swift` to use `AnimationDuration.transition`

## Why
- Eliminated magic number `0.3` from quiz animation code
- Improved consistency with existing design constant system
- Makes future duration adjustments easier to manage

## Result
Animation duration for question transitions is now controlled through a single named constant alongside the rest of the design system.

